### PR TITLE
Features/raycaster oriented sprites

### DIFF
--- a/src/modules/raycaster.c
+++ b/src/modules/raycaster.c
@@ -165,7 +165,14 @@ static int module_raycaster_renderer_render(lua_State* L) {
     else {
         texture_t* sprite = luaL_checktexture(L, 2);
         mfloat_t* position = luaL_checkvector2(L, 3);
-        raycaster_renderer_render_sprite(renderer, sprite, position);
+
+        if (lua_gettop(L) > 3) {
+            mfloat_t* forward = luaL_checkvector2(L, 4);
+            raycaster_renderer_render_sprite_oriented(renderer, sprite, position, forward);
+        }
+        else {
+            raycaster_renderer_render_sprite(renderer, sprite, position);
+        }
     }
 
     return 0;

--- a/src/modules/raycaster.c
+++ b/src/modules/raycaster.c
@@ -132,6 +132,14 @@ static texture_t* palette[MAX_PALETTE_SIZE];
  * @tparam texture.texture sprite Sprite to render.
  * @tparam vector2.vector2 position Position of sprite.
 */
+
+/**
+ * Renders given sprite with orientation.
+ * @function Renderer:render
+ * @tparam texture.texture sprite Sprite to render.
+ * @tparam vector2.vector2 position Position of sprite.
+ * @tparam vector2.vector2 forward Forward vector of sprite.
+*/
 static int module_raycaster_renderer_render(lua_State* L) {
     raycaster_renderer_t* renderer = luaL_checkrayrenderer(L, 1);
 

--- a/src/modules/raycaster.c
+++ b/src/modules/raycaster.c
@@ -124,14 +124,14 @@ static texture_t* palette[MAX_PALETTE_SIZE];
  * @function Renderer:render
  * @tparam Map map Map to render.
  * @tparam {texture.texture,...} tiles An array of textures. Valid range of indices is 0-255.
-*/
+ */
 
 /**
  * Renders given sprite.
  * @function Renderer:render
  * @tparam texture.texture sprite Sprite to render.
  * @tparam vector2.vector2 position Position of sprite.
-*/
+ */
 
 /**
  * Renders given sprite with orientation.
@@ -139,7 +139,7 @@ static texture_t* palette[MAX_PALETTE_SIZE];
  * @tparam texture.texture sprite Sprite to render.
  * @tparam vector2.vector2 position Position of sprite.
  * @tparam vector2.vector2 forward Forward vector of sprite.
-*/
+ */
 static int module_raycaster_renderer_render(lua_State* L) {
     raycaster_renderer_t* renderer = luaL_checkrayrenderer(L, 1);
 

--- a/src/renderers/raycaster.c
+++ b/src/renderers/raycaster.c
@@ -846,31 +846,11 @@ void raycaster_renderer_render_sprite_oriented(raycaster_renderer_t* renderer, t
     vec3_subtract(l, p, half_tangent);
     vec3_add(r, p, half_tangent);
 
-    // int left_bound = l[0] * distance_to_projection_plane / l[1];
-    // int right_bound = r[0] * distance_to_projection_plane / r[1];
-
     mfloat_t t[VEC2_SIZE];
     vec2(t, -l[0], -l[1]);
     mfloat_t f[VEC3_SIZE];
     vec3(f, 0, 0, 1.0f);
     vec2_tangent(f, tangent);
-    //float align = vec2_dot(f, t);
-
-    // if (align >= 0) {
-    //     float swap = r[0];
-    //     r[0] = l[0];
-    //     l[0] = swap;
-    //     swap = r[1];
-    //     r[1] = l[1];
-    //     l[1] = swap;
-
-    //     swap = right_bound;
-    //     right_bound = left_bound;
-    //     left_bound = (int)swap;
-    // }
-
-    // Ensure correct direction of tangent
-
 
     char msg[1024];
     sprintf(msg, "l[0]: %f, r[1]: %f", l[0], l[1]);
@@ -917,7 +897,6 @@ void raycaster_renderer_render_sprite_oriented(raycaster_renderer_t* renderer, t
     }
 
     // Check left clip plane
-
     vec2(clip, half_width, distance_to_projection_plane);
     vec2_normalize(clip, clip);
     vec2_tangent(clip, clip);

--- a/src/renderers/raycaster.c
+++ b/src/renderers/raycaster.c
@@ -885,12 +885,6 @@ void raycaster_renderer_render_sprite_oriented(raycaster_renderer_t* renderer, t
         return;
     }
 
-    // Far culling
-    if (l[1] >= fog_distance && r[1] >= fog_distance) {
-        draw_text("clip far", 0, 40);
-        return;
-    }
-
     mfloat_t ll[VEC3_SIZE];
     mfloat_t rr[VEC3_SIZE];
     vec3_assign(ll, l);
@@ -953,7 +947,7 @@ void raycaster_renderer_render_sprite_oriented(raycaster_renderer_t* renderer, t
         if (intersect(inter, ll, rr, ray)) {
             float distance = inter[1];
 
-            if (distance <= 0 || distance >= fog_distance) continue;
+            if (distance <= 0) continue;
 
             float brightness = get_distance_based_brightness(distance);
             float hh = ((distance_to_projection_plane / distance) * 0.5f);

--- a/src/renderers/raycaster.c
+++ b/src/renderers/raycaster.c
@@ -757,13 +757,25 @@ void raycaster_renderer_render_sprite(raycaster_renderer_t* renderer, texture_t*
     );
 }
 
-static bool intersect(mfloat_t* result, mfloat_t* l, mfloat_t* r, mfloat_t* ray) {
-    float x1 = l[0];
-    float y1 = l[1];
-    float x2 = r[0];
-    float y2 = r[1];
-    float x3 = ray[0];
-    float y3 = ray[1];
+/**
+ * Test intersection for given line segment and ray having origin at 0, 0
+ *
+ * @param result intersection point if intersection occurs.
+ * @param l first endpoint
+ * @param r second endpoint
+ * @param ray direction of ray
+ * @return true if intersection occurs, false otherwise.
+ */
+static bool intersect_camera_ray(mfloat_t* result, mfloat_t* a, mfloat_t* b, mfloat_t* ray) {
+    mfloat_t r[VEC2_SIZE];
+    vec2_normalize(r, ray);
+
+    float x1 = a[0];
+    float y1 = a[1];
+    float x2 = b[0];
+    float y2 = b[1];
+    float x3 = r[0];
+    float y3 = r[1];
     float x4 = 0;
     float y4 = 0;
 
@@ -778,11 +790,11 @@ static bool intersect(mfloat_t* result, mfloat_t* l, mfloat_t* r, mfloat_t* ray)
         return false;
     }
 
-    float a = x1 * y2 - y1 * x2;
-    float b = x3 * y4 - y3 * x4;
+    float t = x1 * y2 - y1 * x2;
+    float u = x3 * y4 - y3 * x4;
 
-    float x = (a * x34 - b * x12) / c;
-    float y = (a * y34 - b * y12) / c;
+    float x = (t * x34 - u * x12) / c;
+    float y = (t * y34 - u * y12) / c;
 
     result[0] = x;
     result[1] = y;
@@ -942,7 +954,7 @@ void raycaster_renderer_render_sprite_oriented(raycaster_renderer_t* renderer, t
 
     for (int i = left_bound; i > right_bound; i--) {
         ray[0] = i;
-        if (intersect(inter, ll, rr, ray)) {
+        if (intersect_camera_ray(inter, ll, rr, ray)) {
             float distance = inter[1];
 
             if (distance <= 0) continue;

--- a/src/renderers/raycaster.c
+++ b/src/renderers/raycaster.c
@@ -813,26 +813,6 @@ void raycaster_renderer_render_sprite_oriented(raycaster_renderer_t* renderer, t
     const float fov_rads = fov * M_PI / 180.0f;
     const float distance_to_projection_plane = half_width / tanf(fov_rads / 2.0f);
 
-    // Calculate sprite projected distance
-    mfloat_t dir[VEC2_SIZE];
-    vec2_subtract(dir, position, camera_position);
-    float distance = vec2_dot(direction, dir);
-
-    // Cull sprites outside near/far planes
-    //if (distance < 0) return;
-    //if (distance >= fog_distance) return;
-
-    // Frustum culling
-    mfloat_t d[VEC2_SIZE];
-    vec2_assign(d, dir);
-    vec2_normalize(d, d);
-
-    // float ang = acos(vec2_dot(direction, d));
-    // if (ang > (fov_rads / 2.0f) + 0.175f) return;
-
-    //Set sprite depth for blit func
-    //sprite_depth = distance;
-
     mfloat_t angle = vec2_angle(direction);
     angle -= MPI_2;
 
@@ -917,7 +897,6 @@ void raycaster_renderer_render_sprite_oriented(raycaster_renderer_t* renderer, t
     vec3_assign(rr, r);
 
     // // Frustum culling
-    //if (right_bound > half_width || left_bound < -half_width) return;
     mfloat_t clip[VEC2_SIZE];
     vec2(clip, -half_width, distance_to_projection_plane);
     vec2_normalize(clip, clip);

--- a/src/renderers/raycaster.c
+++ b/src/renderers/raycaster.c
@@ -841,6 +841,7 @@ void raycaster_renderer_render_sprite_oriented(raycaster_renderer_t* renderer, t
     mfloat_t tangent[VEC3_SIZE];
     vec3(tangent, 0, 0, 1.0f);
     vec2_tangent(tangent, forward);
+    vec2_normalize(tangent, tangent);
     m[6] = 0;
     m[7] = 0;
     vec3_multiply_mat3(tangent, tangent, m);

--- a/src/renderers/raycaster.c
+++ b/src/renderers/raycaster.c
@@ -800,9 +800,6 @@ void raycaster_renderer_render_sprite_oriented(raycaster_renderer_t* renderer, t
     mfloat_t* direction = renderer->camera.direction;
     mfloat_t* camera_position = renderer->camera.position;
 
-    shade_table = renderer->features.shade_table;
-    fog_distance = renderer->features.fog_distance;
-
     const float width = render_texture->width;
     const float height = render_texture->height;
     const float half_width = width / 2.0f;

--- a/src/renderers/raycaster.c
+++ b/src/renderers/raycaster.c
@@ -767,15 +767,12 @@ void raycaster_renderer_render_sprite(raycaster_renderer_t* renderer, texture_t*
  * @return true if intersection occurs, false otherwise.
  */
 static bool intersect_camera_ray(mfloat_t* result, mfloat_t* a, mfloat_t* b, mfloat_t* ray) {
-    mfloat_t r[VEC2_SIZE];
-    vec2_normalize(r, ray);
-
     float x1 = a[0];
     float y1 = a[1];
     float x2 = b[0];
     float y2 = b[1];
-    float x3 = r[0];
-    float y3 = r[1];
+    float x3 = ray[0];
+    float y3 = ray[1];
     float x4 = 0;
     float y4 = 0;
 

--- a/src/renderers/raycaster.c
+++ b/src/renderers/raycaster.c
@@ -852,15 +852,8 @@ void raycaster_renderer_render_sprite_oriented(raycaster_renderer_t* renderer, t
     vec3(f, 0, 0, 1.0f);
     vec2_tangent(f, tangent);
 
-    char msg[1024];
-    sprintf(msg, "l[0]: %f, r[1]: %f", l[0], l[1]);
-    draw_text(msg, 0, 32);
-
     // Near culling
-    if (l[1] <= 0 && r[1] <= 0) {
-        draw_text("clip near", 0, 40);
-        return;
-    }
+    if (l[1] <= 0 && r[1] <= 0) return;
 
     mfloat_t ll[VEC3_SIZE];
     mfloat_t rr[VEC3_SIZE];
@@ -880,10 +873,7 @@ void raycaster_renderer_render_sprite_oriented(raycaster_renderer_t* renderer, t
     a = vec2_dot(clip, ll);
     b = vec2_dot(clip, rr);
 
-    if (a <= 0 && b <= 0) {
-        draw_text("clip right", 0, 40);
-        return;
-    }
+    if (a <= 0 && b <= 0) return;
 
     if (a > 0 && b < 0) {
         float f = a / (a - b);
@@ -905,10 +895,7 @@ void raycaster_renderer_render_sprite_oriented(raycaster_renderer_t* renderer, t
     a = vec2_dot(clip, ll);
     b = vec2_dot(clip, rr);
 
-    if (a <= 0 && b <= 0) {
-        draw_text("clip left", 0, 40);
-        return;
-    }
+    if (a <= 0 && b <= 0) return;
 
     if (a < 0 && b > 0) {
         float f = fabs(a) / (b - a);
@@ -983,61 +970,4 @@ void raycaster_renderer_render_sprite_oriented(raycaster_renderer_t* renderer, t
             );
         }
     }
-
-    sprintf(msg, "lb: %i, rb: %i", left_bound, right_bound);
-    draw_text(msg, 0, 40);
-
-    sprintf(msg, "align: %f", align);
-    draw_text(msg, 0, 48);
-
-    draw_line(160, 100, 160 + half_width, 100 - distance_to_projection_plane, 15);
-    draw_line(160, 100, 160 - half_width, 100 - distance_to_projection_plane, 15);
-
-    float scalar = 72.0f;
-
-    draw_line(
-        160 - l[0] * scalar,
-        100 - l[1] * scalar,
-        160 - r[0] * scalar,
-        100 - r[1] * scalar,
-        14
-    );
-
-    draw_line(
-        160 - ll[0] * scalar,
-        100 - ll[1] * scalar,
-        160 - rr[0] * scalar,
-        100 - rr[1] * scalar,
-        11
-    );
-
-    draw_filled_rectangle(
-        160 - l[0] * scalar - 1,
-        100 - l[1] * scalar - 1,
-        3,
-        3,
-        12
-    );
-
-    draw_circle(
-        160 - ll[0] * scalar,
-        100 - ll[1] * scalar,
-        1,
-        12
-    );
-
-    draw_circle(
-        160 - rr[0] * scalar,
-        100 - rr[1] * scalar,
-        1,
-        10
-    );
-
-    draw_filled_rectangle(
-        160 - r[0] * scalar - 1,
-        100 - r[1] * scalar - 1,
-        3,
-        3,
-        10
-    );
 }

--- a/src/renderers/raycaster.c
+++ b/src/renderers/raycaster.c
@@ -911,8 +911,8 @@ void raycaster_renderer_render_sprite_oriented(raycaster_renderer_t* renderer, t
     }
 
     // Flip
-    int left_bound = ll[0] * distance_to_projection_plane / ll[1];
-    int right_bound = rr[0] * distance_to_projection_plane / rr[1];
+    int left_bound = ll[0] * distance_to_projection_plane / ll[1] - 0.5f;
+    int right_bound = rr[0] * distance_to_projection_plane / rr[1] + 0.5f;
 
     float align = vec2_dot(f, t);
 

--- a/src/renderers/raycaster.c
+++ b/src/renderers/raycaster.c
@@ -850,12 +850,6 @@ void raycaster_renderer_render_sprite_oriented(raycaster_renderer_t* renderer, t
     r[1] = position[1] - t[1] / 2.0f - camera_position[1];
     r[2] = 1;
 
-    mfloat_t v[VEC3_SIZE];
-    v[0] = position[0] - camera_position[0];
-    v[1] = position[1] - camera_position[1];
-    v[2] = 1;
-
-    vec3_multiply_mat3(v, v, m);
     vec3_multiply_mat3(l, l, m);
     vec3_multiply_mat3(r, r, m);
 

--- a/src/renderers/raycaster.c
+++ b/src/renderers/raycaster.c
@@ -522,8 +522,7 @@ void raycaster_renderer_render_map(raycaster_renderer_t* renderer, raycaster_map
      */
 
     // 1. Determine distance to the projection plane.
-    const float fov_rads = fov * M_PI / 180.0f;
-    const float distance_to_projection_plane = (width / 2.0f) / tanf(fov_rads / 2.0f);
+    const float distance_to_projection_plane = (width / 2.0f) / tanf(to_radians(fov) / 2.0f);
 
     // Calculate step vector, we need it to move along the projection plane
     mfloat_t step[VEC2_SIZE];
@@ -705,8 +704,7 @@ void raycaster_renderer_render_sprite(raycaster_renderer_t* renderer, texture_t*
     const float height = render_texture->height;
 
     const float fov = renderer->camera.fov;
-    const float fov_rads = fov * M_PI / 180.0f;
-    const float distance_to_projection_plane = (width / 2.0f) / tanf(fov_rads / 2.0f);
+    const float distance_to_projection_plane = (width / 2.0f) / tanf(to_radians(fov) / 2.0f);
 
     // Calculate step vector, we need it to move along the projection plane
     mfloat_t step[VEC2_SIZE];
@@ -728,7 +726,7 @@ void raycaster_renderer_render_sprite(raycaster_renderer_t* renderer, texture_t*
     vec2_normalize(d, d);
 
     float ang = acos(vec2_dot(direction, d));
-    if (ang > (fov_rads / 2.0f) + 0.175f) return;
+    if (ang > (to_radians(fov) / 2.0f) + 0.175f) return;
 
     // Scale to put point on projection plane.
     vec2_multiply_f(dir, dir, distance_to_projection_plane / distance);
@@ -810,8 +808,7 @@ void raycaster_renderer_render_sprite_oriented(raycaster_renderer_t* renderer, t
     const float half_width = width / 2.0f;
 
     const float fov = renderer->camera.fov;
-    const float fov_rads = fov * M_PI / 180.0f;
-    const float distance_to_projection_plane = half_width / tanf(fov_rads / 2.0f);
+    const float distance_to_projection_plane = half_width / tanf(to_radians(fov) / 2.0f);
 
     mfloat_t angle = vec2_angle(direction);
     angle -= MPI_2;

--- a/src/renderers/raycaster.c
+++ b/src/renderers/raycaster.c
@@ -933,8 +933,8 @@ void raycaster_renderer_render_sprite_oriented(raycaster_renderer_t* renderer, t
     }
 
     // Flip
-    int left_bound = l[0] * distance_to_projection_plane / l[1] - 0.5f;
-    int right_bound = r[0] * distance_to_projection_plane / r[1] + 0.5f;
+    float left_bound = l[0] * distance_to_projection_plane / l[1];
+    float right_bound = r[0] * distance_to_projection_plane / r[1];
 
     if (right_bound > left_bound) {
         float swap = b[0];
@@ -960,8 +960,8 @@ void raycaster_renderer_render_sprite_oriented(raycaster_renderer_t* renderer, t
     vec3_subtract(tangent, b, a);
 
     // Clamp to visible bounds
-    left_bound = (int)fmin(left_bound, half_width);
-    right_bound = (int)fmax(right_bound, -half_width);
+    left_bound = fminf(left_bound, half_width);
+    right_bound = fmaxf(right_bound, -half_width);
 
     mfloat_t intersection[VEC2_SIZE];
     mfloat_t ray[VEC2_SIZE];

--- a/src/renderers/raycaster.c
+++ b/src/renderers/raycaster.c
@@ -972,14 +972,18 @@ void raycaster_renderer_render_sprite_oriented(raycaster_renderer_t* renderer, t
         ray[0] = i;
         if (intersect_camera_ray(intersection, l, r, ray)) {
             float distance = intersection[1];
-
             if (distance <= 0) continue;
 
             float brightness = get_distance_based_brightness(distance);
             float half_sprite_height = ((distance_to_projection_plane / distance) * 0.5f);
             vec3_subtract(p, intersection, a);
             p[2] = 0;
+
             float offset = vec3_dot(p, tangent);
+
+            // TODO: Fix this hack. My hunch is related to pixel centers and
+            // calculating the left and right bounds.
+            if (offset < 0 || offset > 1.0f) continue;
 
             draw_wall_strip(
                 sprite,

--- a/src/renderers/raycaster.c
+++ b/src/renderers/raycaster.c
@@ -957,8 +957,8 @@ void raycaster_renderer_render_sprite_oriented(raycaster_renderer_t* renderer, t
                 sprite,
                 render_texture,
                 half_width - i,
-                (height / 2.0f) - hh,
-                (height / 2.0f) + hh,
+                (height / 2.0f) - hh - 0.5f,
+                (height / 2.0f) + hh + 1.5f,
                 offset,
                 brightness,
                 distance

--- a/src/renderers/raycaster.c
+++ b/src/renderers/raycaster.c
@@ -835,31 +835,8 @@ void raycaster_renderer_render_sprite_oriented(raycaster_renderer_t* renderer, t
     // Scale to put point on projection plane.
     vec2_multiply_f(dir, dir, distance_to_projection_plane / distance);
 
-    // Find x offset
-    float x_offset = vec2_dot(dir, step);
-
-    float s_height = 1.0f / distance * distance_to_projection_plane;
-    float half_height = s_height / 2.0f;
-
-    rect_t rect = {
-        (width / 2.0f) + x_offset - half_height,
-        (height / 2.0f) - half_height,
-        s_height,
-        s_height
-    };
-
     // Set sprite depth for blit func
     sprite_depth = distance;
-
-    // Draw sprite
-    // graphics_blit(
-    //     sprite,
-    //     render_texture,
-    //     NULL,
-    //     &rect,
-    //     sprite_depth_blit_func
-    // );
-
 
     mfloat_t angle = vec2_angle(direction);
     angle -= MPI_2;
@@ -870,7 +847,6 @@ void raycaster_renderer_render_sprite_oriented(raycaster_renderer_t* renderer, t
 
     mfloat_t t[VEC2_SIZE];
     vec2_tangent(t, forward);
-    //vec2_divide_f(t, t, 2.0f);
 
     mfloat_t l[VEC3_SIZE];
     l[0] = position[0] + t[0] / 2.0f - camera_position[0];
@@ -891,18 +867,6 @@ void raycaster_renderer_render_sprite_oriented(raycaster_renderer_t* renderer, t
     vec3_multiply_mat3(l, l, m);
     vec3_multiply_mat3(r, r, m);
 
-    int rc = 11;
-    int lc = 12;
-
-    // if (r[0] < l[0]) {
-    //     float swap = r[0];
-    //     r[0] = l[0];
-    //     l[0] = swap;
-    //     swap = r[1];
-    //     r[1] = l[1];
-    //     l[1] = swap;
-    // }
-
     int left_bound = l[0] * distance_to_projection_plane / l[1];
     int right_bound = r[0] * distance_to_projection_plane / r[1];
 
@@ -919,30 +883,11 @@ void raycaster_renderer_render_sprite_oriented(raycaster_renderer_t* renderer, t
         left_bound = (int)swap;
     }
 
-    // draw_line(
-    //     (width / 2.0f) + x_offset,
-    //     (height / 2.0f) - half_height,
-    //     (width / 2.0f) + x_offset,
-    //     (height / 2.0f) + half_height - 1,
-    //     13
-    // );
-
-    float s = distance_to_projection_plane / l[1];
-    float u = s * l[0];
-    float hh = s / 2.0f;
-
-    // char msg[1024];
-    // sprintf(msg, "left: %i, right: %i", left_bound, right_bound);
-    // draw_text(msg, 0, 32);
-
     mfloat_t inter[VEC2_SIZE];
     mfloat_t ray[VEC2_SIZE];
     vec2(ray, left_bound, distance_to_projection_plane);
 
     intersect(inter, l, r, ray);
-
-    int start = fmax(left_bound, width / -2.0f);
-    int stop = fmin(right_bound, width / 2.0f);
 
     for (int i = left_bound; i <= right_bound; i++) {
         ray[0] = i;
@@ -959,27 +904,4 @@ void raycaster_renderer_render_sprite_oriented(raycaster_renderer_t* renderer, t
             );
         }
     }
-
-    // draw_line(
-    //     width / 2.0f - left_bound,
-    //     (height / 2.0f) - hh,
-    //     width / 2.0f - left_bound,
-    //     (height / 2.0f) + hh,
-    //     lc
-    // );
-
-    s = distance_to_projection_plane / r[1];
-    u = s * r[0];
-    hh = s / 2.0f;
-
-    //sprintf(msg, "right: %f", (width / 2.0f) - u);
-    //draw_text(msg, 0, 40);
-
-    // draw_line(
-    //     width / 2.0f - right_bound,
-    //     (height / 2.0f) - hh,
-    //     width / 2.0f - right_bound,
-    //     (height / 2.0f) + hh,
-    //     rc
-    // );
 }

--- a/src/renderers/raycaster.c
+++ b/src/renderers/raycaster.c
@@ -914,9 +914,7 @@ void raycaster_renderer_render_sprite_oriented(raycaster_renderer_t* renderer, t
     int left_bound = ll[0] * distance_to_projection_plane / ll[1] - 0.5f;
     int right_bound = rr[0] * distance_to_projection_plane / rr[1] + 0.5f;
 
-    float align = vec2_dot(f, t);
-
-    if (align >= 0) {
+    if (right_bound > left_bound) {
         float swap = r[0];
         r[0] = l[0];
         l[0] = swap;

--- a/src/renderers/raycaster.c
+++ b/src/renderers/raycaster.c
@@ -876,7 +876,10 @@ void raycaster_renderer_render_sprite_oriented(raycaster_renderer_t* renderer, t
         vec2_normalize(clip_plane_normal, clip_plane_normal);
         vec2_tangent(clip_plane_normal, clip_plane_normal);
 
+        /** Clipped left endpoint projected onto clip plane normal.*/
         float aa = vec2_dot(clip_plane_normal, l);
+
+        /** Clipped right endpoint projected onto clip plane normal.*/
         float bb = vec2_dot(clip_plane_normal, r);
 
         // Both endpoints are outside clipping plane.
@@ -906,7 +909,10 @@ void raycaster_renderer_render_sprite_oriented(raycaster_renderer_t* renderer, t
         vec2_tangent(clip_plane_normal, clip_plane_normal);
         vec2_multiply_f(clip_plane_normal, clip_plane_normal, -1.0f);
 
+        /** Clipped left endpoint projected onto clip plane normal.*/
         float aa = vec2_dot(clip_plane_normal, l);
+
+        /** Clipped right endpoint projected onto clip plane normal.*/
         float bb = vec2_dot(clip_plane_normal, r);
 
         // Both endpoints are outside clipping plane.

--- a/src/renderers/raycaster.c
+++ b/src/renderers/raycaster.c
@@ -810,11 +810,6 @@ void raycaster_renderer_render_sprite_oriented(raycaster_renderer_t* renderer, t
     const float fov_rads = fov * M_PI / 180.0f;
     const float distance_to_projection_plane = (width / 2.0f) / tanf(fov_rads / 2.0f);
 
-    // Calculate step vector, we need it to move along the projection plane
-    mfloat_t step[VEC2_SIZE];
-    vec2_tangent(step, direction);
-    vec2_negative(step, step);
-
     // Calculate sprite projected distance
     mfloat_t dir[VEC2_SIZE];
     vec2_subtract(dir, position, camera_position);
@@ -831,9 +826,6 @@ void raycaster_renderer_render_sprite_oriented(raycaster_renderer_t* renderer, t
 
     float ang = acos(vec2_dot(direction, d));
     if (ang > (fov_rads / 2.0f) + 0.175f) return;
-
-    // Scale to put point on projection plane.
-    vec2_multiply_f(dir, dir, distance_to_projection_plane / distance);
 
     // Set sprite depth for blit func
     sprite_depth = distance;

--- a/src/renderers/raycaster.h
+++ b/src/renderers/raycaster.h
@@ -109,6 +109,14 @@ void raycaster_renderer_render_map(raycaster_renderer_t* renderer, raycaster_map
  */
 void raycaster_renderer_render_sprite(raycaster_renderer_t* renderer, texture_t* sprite, mfloat_t* position);
 
+/**
+ * Render given texture as an oriented sprite.
+ *
+ * @param renderer Renderer to render to.
+ * @param sprite Texture to render.
+ * @param position Sprite position.
+ * @param forward Sprite forward vector.
+ */
 void raycaster_renderer_render_sprite_oriented(raycaster_renderer_t* renderer, texture_t* sprite, mfloat_t* position, mfloat_t* forward);
 
 #endif

--- a/src/renderers/raycaster.h
+++ b/src/renderers/raycaster.h
@@ -113,4 +113,6 @@ void raycaster_renderer_render_map(raycaster_renderer_t* renderer, raycaster_map
  */
 void raycaster_renderer_render_sprite(raycaster_renderer_t* renderer, texture_t* sprite, mfloat_t* position);
 
+void raycaster_renderer_render_sprite_oriented(raycaster_renderer_t* renderer, texture_t* sprite, mfloat_t* position, mfloat_t* forward);
+
 #endif

--- a/src/renderers/raycaster.h
+++ b/src/renderers/raycaster.h
@@ -1,10 +1,6 @@
 #ifndef RENDERERS_RAYCASTER_H
 #define RENDERERS_RAYCASTER_H
 
-#ifndef M_PI
-#define M_PI 3.14159265359
-#endif
-
 #include <stdbool.h>
 #include <mathc/mathc.h>
 


### PR DESCRIPTION
## Summary
Adds support for drawing oriented sprites. Adds a new function `raycaster_renderer_render_sprite_oriented` to `src/renderers/raycaster.c`.

## Usage
Extends raycaster `renderer:render` to take an optional third forward parameter. If present, the renderer will render the sprite as oriented.
```lua
renderer:render(texture, position, forward)
```

## Review Guide

### src/modules/raycaster.c
- Updated Lua bindings to check for optional forward vector.

### src/renderers/raycaster.h
- Removed redundant definition of pi.
- Added new function for rendering oriented sprites.

### src/renderers/raycaster.c
- Implemented rendering of oriented sprites. The approach here uses a transformation matrix to perform rendering in camera space. This has a few benefits:
  1. Clip planes are easily calculated.
  2. Distance required for raycasting is just the y-coordinate of the intersection of the sprite and camera ray.