### PR TITLE
Fix visual artifacts on Mac

### DIFF
--- a/src/platforms/desktop.c
+++ b/src/platforms/desktop.c
@@ -179,6 +179,8 @@ void platform_draw(void) {
         render_texture->width * sizeof(uint32_t)
     );
 
+    SDL_RenderClear(renderer);
+
     SDL_RenderCopy(
         renderer,
         render_buffer_texture,


### PR DESCRIPTION
<img width="750" alt="Screenshot 2024-08-04 at 2 10 36 PM" src="https://github.com/user-attachments/assets/336a0609-ac97-4f60-a86a-673cc7c13a96">

# Summary
When using `SDLRenderCopy` to only update a portion of the screen, visual artifacting occurs. In my testing this only occurs on M series Macs.

# Fix
Calling `SDL_RenderClear` before `SDLRenderCopy` ensures that no garbage data is present.

# Related
https://github.com/libsdl-org/SDL/issues/1197