### PR TITLE
Enhance SDL Initialization Hints

### DIFF
--- a/src/platforms/desktop-opengl.c
+++ b/src/platforms/desktop-opengl.c
@@ -90,6 +90,17 @@ void platform_init(void) {
     if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO) != 0) {
         log_fatal("Error initializing SDL");
     }
+    
+    // Set the scaling algorithm to nearest-neighbor for crisp pixel art rendering.
+    // This ensures that pixel art graphics remain sharp when scaled.
+    SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "0");
+
+    // Disable the X11 net WM ping protocol to potentially improve rendering consistency.
+    // This is more relevant for X11 systems but doesn't hurt to include for broader compatibility.
+    SDL_SetHint(SDL_HINT_VIDEO_X11_NET_WM_PING, "0");
+
+    // Force SDL to use OpenGL as the rendering driver.
+    SDL_SetHint(SDL_HINT_RENDER_DRIVER, "opengl");
 
     if (Mix_OpenAudioDevice(11025, AUDIO_U8, 1, 2048, NULL, 0) < 0) {
         log_fatal("Error intializing SDL Mixer");

--- a/src/platforms/desktop.c
+++ b/src/platforms/desktop.c
@@ -69,6 +69,24 @@ void platform_init(void) {
         log_fatal("Error initializing SDL");
     }
 
+    // Set the scaling algorithm to nearest-neighbor for crisp pixel art rendering.
+    // This ensures that pixel art graphics remain sharp when scaled.
+    SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "0");
+
+    // Disable the X11 net WM ping protocol to potentially improve rendering consistency.
+    // This is more relevant for X11 systems but doesn't hurt to include for broader compatibility.
+    SDL_SetHint(SDL_HINT_VIDEO_X11_NET_WM_PING, "0");
+
+    // Force SDL to use OpenGL as the rendering driver.
+    // NOTE: This is somewhat inconsistent with the overall approach of this file (SDL 2D API),
+    // but it helps solve issues with blurry rendering on some systems, particularly high-DPI displays.
+    // Potential implications:
+    // 1. May improve performance and pixel-perfect rendering on some systems;
+    // 2. Could potentially cause compatibility issues on systems without good OpenGL support;
+    // 3. Might have unexpected behavior or performance impacts on certain configurations.
+    // TODO: Consider making this configurable or exploring alternative solutions for blurriness issues
+    SDL_SetHint(SDL_HINT_RENDER_DRIVER, "opengl");
+
     if (Mix_OpenAudioDevice(11025, AUDIO_U8, 1, 2048, NULL, 0) < 0) {
         log_fatal("Error intializing SDL Mixer");
     }


### PR DESCRIPTION
This PR introduces several improvements to the SDL initialization process, aiming to enhance rendering quality and performance across different systems.

## Changes

1. Set the scaling algorithm to nearest-neighbor for sharp pixel art rendering.
2. Disable the X11 net WM ping protocol to potentially improve rendering consistency on X11 systems.
3. Force SDL to use OpenGL as the rendering driver.

## Rationale

- The nearest-neighbor scaling algorithm preserves the sharpness of pixel art graphics when scaled.
- Disabling the X11 net WM ping protocol may improve rendering consistency on some systems.
- Forcing OpenGL as the rendering driver can enhance performance and solve blurriness issues, particularly on high-DPI displays.

## Potential Implications

While these changes aim to improve rendering quality and performance, they may have some side effects:

1. The OpenGL rendering driver might introduce compatibility issues on systems lacking robust OpenGL support.
2. There could be unexpected behavior or performance impacts on certain configurations.

## TODO

Consider making the OpenGL rendering driver configurable or explore alternative solutions for addressing blurriness issues.