### PR TITLE
Features/Subtextures

### DIFF
--- a/library/texture.lua
+++ b/library/texture.lua
@@ -19,6 +19,14 @@ texture.texture = {}
 --- @return texture 
 function texture.texture:copy() end
 
+--- Returns a subtexture that share pixels with this texture.
+--- @param x integer  Subtexture x-offset
+--- @param y integer  Subtexture y-offset
+--- @param width integer  Subtexture width
+--- @param height integer  Subtexture height
+--- @return texture 
+function texture.texture:sub(x, y, width, height) end
+
 --- Fill entire texture with color.
 --- @param color integer  Fill color
 function texture.texture:clear(color) end
@@ -40,5 +48,26 @@ function texture.texture:get_pixel(x, y) end
 --- @param x integer  Destination x-offset
 --- @param y integer  Destination y-offset
 function texture.texture:blit(source, x, y) end
+
+--- Copy given source texture to this texture with given offset and size.
+--- @param source texture  Texture to copy from
+--- @param x integer  Destination x-offset
+--- @param y integer  Destination y-offset
+--- @param w integer  Destination width
+--- @param h integer  Destination height
+function texture.texture:blit(source, x, y, w, h) end
+
+--- Copy given source texture to this texture with given source offset and size,
+ and destination offset and size.
+--- @param source texture  Texture to copy from
+--- @param sx integer  Source x-offset
+--- @param sy integer  Source y-offset
+--- @param sw integer  Source width
+--- @param sh integer  Source height
+--- @param dx integer  Destination x-offset
+--- @param dy integer  Destination y-offset
+--- @param dw integer  Destination width
+--- @param dh integer  Destination height
+function texture.texture:blit(source, sx, sy, sw, sh, dx, dy, dw, dh) end
 
 return texture

--- a/src/assets.c
+++ b/src/assets.c
@@ -814,7 +814,8 @@ static size_t texture_asset_sizeof(texture_asset_t* asset) {
     size_t size = sizeof(texture_asset_t);
 
     for (size_t i = 0; i < asset->frame_count; i++) {
-        size += graphics_texture_sizeof(asset->frames[i]);
+        texture_t* frame = asset->frames[i];
+        size += sizeof(texture_t) + frame->width * frame->height * sizeof(color_t);
     }
 
     return size;

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -52,11 +52,6 @@ void graphics_texture_free(texture_t* texture) {
     texture = NULL;
 }
 
-size_t graphics_texture_sizeof(texture_t* texture) {
-    // TODO Remove this?
-    return sizeof(texture_t) + texture->width * texture->height * sizeof(color_t);
-}
-
 texture_t* graphics_texture_copy(texture_t* texture) {
     texture_t* copy = graphics_texture_new(
         texture->width,

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -14,15 +14,24 @@ static int transparent_color = -1;
 static rect_t clip_rect;
 
 texture_t* graphics_texture_new(int width, int height, const color_t* pixels) {
-    texture_t* texture = (texture_t*)malloc(sizeof(texture_t) + width * height * sizeof(color_t));
+    texture_t* texture = (texture_t*)malloc(sizeof(texture_t));
 
     if (!texture) {
         log_error("Failed to create texture");
         return NULL;
     }
 
+    texture->pixels = (color_t*)malloc(width * height * sizeof(color_t));
+
+    if (!texture->pixels) {
+        log_error("Failed to create texture pixels");
+        return NULL;
+    }
+
     texture->width = width;
     texture->height = height;
+    texture->stride = width;
+    texture->is_subtexture = false;
     memset(texture->pixels, 0, width * height);
 
     if (pixels) {
@@ -34,35 +43,78 @@ texture_t* graphics_texture_new(int width, int height, const color_t* pixels) {
 }
 
 void graphics_texture_free(texture_t* texture) {
+    if (!texture->is_subtexture) {
+        free(texture->pixels);
+        texture->pixels = NULL;
+    }
+
     free(texture);
     texture = NULL;
 }
 
 size_t graphics_texture_sizeof(texture_t* texture) {
+    // TODO Remove this?
     return sizeof(texture_t) + texture->width * texture->height * sizeof(color_t);
 }
 
 texture_t* graphics_texture_copy(texture_t* texture) {
-    return graphics_texture_new(texture->width, texture->height, texture->pixels);
+    texture_t* copy = graphics_texture_new(
+        texture->width,
+        texture->height,
+        NULL
+    );
+
+    size_t size = copy->width * sizeof(color_t);
+    for (int i = 0; i < copy->height; i++) {
+        memmove(
+            copy->pixels + i * copy->stride,
+            texture->pixels + i * texture->stride,
+            size
+        );
+    }
+
+    return copy;
 }
 
 void graphics_texture_clear(texture_t* texture, color_t color) {
-    size_t number_of_bytes = texture->width * texture->height;
-    memset(texture->pixels, color, number_of_bytes);
+    size_t size = texture->width * sizeof(color_t);
+    for (int i = 0; i < texture->height; i++) {
+        memset(texture->pixels + i * texture->stride, color, size);
+    }
+}
+
+texture_t* graphics_texture_sub(texture_t* texture, rect_t* rect) {
+    texture_t* sub_texture = (texture_t*)malloc(sizeof(texture_t));
+
+    if (!sub_texture) {
+        log_error("Failed to create texture");
+        return NULL;
+    }
+
+    sub_texture->width = rect->width;
+    sub_texture->height = rect->height;
+    sub_texture->stride = texture->stride;
+    sub_texture->is_subtexture = true;
+
+    size_t offset = rect->x + rect->y * texture->stride;
+
+    sub_texture->pixels = texture->pixels + offset;
+
+    return sub_texture;
 }
 
 void graphics_texture_pixel_set(texture_t* texture, int x, int y, color_t color) {
     if (x < 0 || x >= texture->width) return;
     if (y < 0 || y >= texture->height) return;
 
-    texture->pixels[y * texture->width + x] = color;
+    texture->pixels[y * texture->stride + x] = color;
 }
 
 color_t graphics_texture_pixel_get(texture_t* texture, int x, int y) {
     if (x < 0 || x >= texture->width) return 0;
     if (y < 0 || y >= texture->height) return 0;
 
-    return texture->pixels[y * texture->width + x];
+    return texture->pixels[y * texture->stride + x];
 }
 
 static void texture_blit_func(texture_t* source_texture, texture_t* destination_texture, int sx, int sy, int dx, int dy) {

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -79,6 +79,16 @@ void graphics_texture_clear(texture_t* texture, color_t color) {
 }
 
 texture_t* graphics_texture_sub(texture_t* texture, rect_t* rect) {
+    if (
+        rect->x < 0 ||
+        rect->y < 0 ||
+        rect->x + rect->width > texture->width ||
+        rect->y + rect->height > texture->height
+        ) {
+        log_error("Subtexture rect outside source texture bounds");
+        return NULL;
+    }
+
     texture_t* sub_texture = (texture_t*)malloc(sizeof(texture_t));
 
     if (!sub_texture) {

--- a/src/graphics.h
+++ b/src/graphics.h
@@ -6,6 +6,7 @@
 #ifndef GRAPHICS_H
 #define GRAPHICS_H
 
+#include <stdbool.h>
 #include <stdint.h>
 
 typedef struct {
@@ -20,7 +21,9 @@ typedef uint8_t color_t;
 typedef struct {
     int width;
     int height;
-    color_t pixels[];
+    int stride;
+    bool is_subtexture;
+    color_t* pixels;
 } texture_t;
 
 /**
@@ -63,6 +66,15 @@ texture_t* graphics_texture_copy(texture_t* texture);
  * @param color Fill color
  */
 void graphics_texture_clear(texture_t* texture, color_t color);
+
+/**
+ * Creates a texture that shares pixels with the given texture.
+ *
+ * @param texture Texture to get subtexture from
+ * @param rect Sub region of given texture to use as subtexture.
+ * @return New texture if successful, NULL otherwise.
+ */
+texture_t* graphics_texture_sub(texture_t* texture, rect_t* rect);
 
 /**
  * Set pixel color.

--- a/src/graphics.h
+++ b/src/graphics.h
@@ -44,14 +44,6 @@ texture_t* graphics_texture_new(int width, int height, const color_t* pixels);
 void graphics_texture_free(texture_t* texture);
 
 /**
- * Returns size of given texture in bytes.
- *
- * @param texture Texture to get sizeof.
- * @return Size of texture in bytes.
- */
-size_t graphics_texture_sizeof(texture_t* texture);
-
-/**
  * Copy given texture
  *
  * @param texture Texture to copy

--- a/src/modules/texture.c
+++ b/src/modules/texture.c
@@ -49,6 +49,14 @@ texture_t* luaL_opttexture(lua_State* L, int index, texture_t* default_) {
 int lua_newtexture(lua_State* L, int width, int height) {
     texture_t** handle = (texture_t**)lua_newuserdata(L, sizeof(texture_t*));
     *handle = graphics_texture_new(width, height, NULL);
+
+    if (!*handle) {
+        luaL_error(L, "error creating texture");
+        lua_settop(L, 0);
+
+        return 0;
+    }
+
     luaL_setmetatable(L, "texture");
 
     return 1;
@@ -177,6 +185,14 @@ static int modules_texture_copy(lua_State* L) {
 
     texture_t** handle = (texture_t**)lua_newuserdata(L, sizeof(texture_t*));
     *handle = graphics_texture_copy(source);
+
+    if (!*handle) {
+        luaL_error(L, "error copying texture");
+        lua_settop(L, 0);
+
+        return 0;
+    }
+
     luaL_setmetatable(L, "texture");
 
     return 1;
@@ -204,6 +220,14 @@ static int modules_texture_sub(lua_State* L) {
 
     texture_t** handle = (texture_t**)lua_newuserdata(L, sizeof(texture_t*));
     *handle = graphics_texture_sub(source, &rect);
+
+    if (!*handle) {
+        luaL_error(L, "error creating subtexture");
+        lua_settop(L, 0);
+
+        return 0;
+    }
+
     luaL_setmetatable(L, "texture");
 
     return 1;

--- a/src/modules/texture.c
+++ b/src/modules/texture.c
@@ -183,6 +183,33 @@ static int modules_texture_copy(lua_State* L) {
 }
 
 /**
+ * Returns a subtexture that share pixels with this texture.
+ * @function sub
+ * @tparam integer x Subtexture x-offset
+ * @tparam integer y Subtexture y-offset
+ * @tparam integer width Subtexture width
+ * @tparam integer height Subtexture height
+ * @treturn texture
+ */
+static int modules_texture_sub(lua_State* L) {
+    texture_t* source = luaL_checktexture(L, 1);
+    int x = (int)luaL_checknumber(L, 2);
+    int y = (int)luaL_checknumber(L, 3);
+    int w = (int)luaL_checknumber(L, 4);
+    int h = (int)luaL_checknumber(L, 5);
+
+    lua_pop(L, -1);
+
+    rect_t rect = {x, y, w, h};
+
+    texture_t** handle = (texture_t**)lua_newuserdata(L, sizeof(texture_t*));
+    *handle = graphics_texture_sub(source, &rect);
+    luaL_setmetatable(L, "texture");
+
+    return 1;
+}
+
+/**
  * Fill entire texture with color.
  * @function clear
  * @tparam integer color Fill color
@@ -331,6 +358,7 @@ static int modules_texture_blit(lua_State* L) {
 static const struct luaL_Reg modules_texture_functions[] = {
     {"new", modules_texture_new},
     {"copy", modules_texture_copy},
+    {"sub", modules_texture_sub},
     {"clear", modules_texture_clear},
     {"set_pixel", modules_texture_pixel_set},
     {"get_pixel", modules_texture_pixel_get},


### PR DESCRIPTION
# Subtextures

```Lua
-- example
source = texture.new(32, 32)
sub = source:sub(0, 0, 16, 16)
```

## Summary
Provides subtexture functionality. A subtexture is just a texture, but it shares pixel data with a source texture. This makes sprite sheets/texture atlasing much easier.

## PR Guide
### graphics.c
The main function of interest is the sub texture implementation:
```C
texture_t* graphics_texture_sub(texture_t* texture, rect_t* rect);
```
Which creates a new `texture_t` and points it's pixels to the source textures pixels. It also keeps the parents `stride` so it can correctly traverse the underlying pixel data.

The `texture_t` struct has been updated:
```C
typedef struct {
    int width;
    int height;
    int stride; // New
    bool is_subtexture; // New
    color_t* pixels; // Was flexible array member, now a pointer
} texture_t;
```
The `stride` is always the width of the underlying pixel data. `is_subtexture` is a flag to prevent cleaning up pixel data when freeing a texture. `pixels` was a flexible array member, now is a pointer to facilitate the pixel data sharing.

The clear and copy functions now use memory manipulation functions on a per row basis instead of the entirety of the pixel data.

### texture.c
Lua implementation is very straightforward. Null checks were added to all texture functions to guard against segfaults.