### PR TITLE
Rename keyboard.scancodes to keyboard.keys

### DIFF
--- a/library/keyboard.lua
+++ b/library/keyboard.lua
@@ -9,7 +9,7 @@ local keyboard = {}
 function keyboard.key(code_or_symbol) end
 
 --- Key scancode nums
-keyboard.scancodes = {
+keyboard.keys = {
     A = 4,
     B = 5,
     C = 6,

--- a/src/modules/gamecontroller.c
+++ b/src/modules/gamecontroller.c
@@ -243,11 +243,9 @@ int luaopen_gamecontroller(lua_State* L) {
     luaL_newlib(L, modules_gamecontroller_functions);
 
     gamecontroller_button_enums(L);
-    //make_readonly(L);
     lua_setfield(L, -2, "buttons");
 
     gamecontroller_button_axes(L);
-    //make_readonly(L);
     lua_setfield(L, -2, "axes");
 
     return 1;

--- a/src/modules/keyboard.c
+++ b/src/modules/keyboard.c
@@ -50,8 +50,8 @@ struct luaL_Field {
  */
 
 /**
- * Scancode enums
- * @table scancodes
+ * Key scancode enums
+ * @table keys
  *
  * @tfield integer A
  * @tfield integer B
@@ -564,7 +564,7 @@ int luaopen_keyboard(lua_State* L) {
     luaL_newlib(L, modules_keyboard_functions);
 
     keyboard_scan_code_table(L);
-    lua_setfield(L, -2, "scancodes");
+    lua_setfield(L, -2, "keys");
 
     return 1;
 }


### PR DESCRIPTION
## Summary
Renames `keyboard.scancodes` to `keyboard.keys`