### PR TITLE
Enable no audio mode

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -78,7 +78,7 @@ jobs:
     - name: Copy demos
       run: cp -r demos ./dist/${{ env.engine_ver }}
     - name: Copy dlls
-      run: cp /mingw64/bin/SDL2.dll /mingw64/bin/SDL2_mixer.dll /mingw64/bin/glew32.dll /mingw64/bin/libmpg123-0.dll /mingw64/bin/libopusfile-0.dll /mingw64/bin/libogg-0.dll /mingw64/bin/libopus-0.dll /mingw64/bin/libmodplug-1.dll /mingw64/bin/libstdc++-6.dll /mingw64/bin/libgcc_s_seh-1.dll /mingw64/bin/libwinpthread-1.dll ./dist/${{ env.engine_ver }}
+      run: cp /mingw64/bin/SDL2.dll /mingw64/bin/SDL2_mixer.dll /mingw64/bin/glew32.dll /mingw64/bin/libmpg123-0.dll /mingw64/bin/libopusfile-0.dll /mingw64/bin/libogg-0.dll /mingw64/bin/libopus-0.dll /mingw64/bin/libstdc++-6.dll /mingw64/bin/libgcc_s_seh-1.dll /mingw64/bin/libwinpthread-1.dll ./dist/${{ env.engine_ver }}
     - name: Copy docs
       run: cp -r docs ./dist/${{ env.engine_ver }}
     - name: Package artifacts

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,8 +16,8 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    - uses: leafo/gh-actions-lua@v9
-    - uses: leafo/gh-actions-luarocks@v4
+    - uses: leafo/gh-actions-lua@v11
+    - uses: leafo/gh-actions-luarocks@v5
 
     # Install some package
     - name: Install LDoc

--- a/src/platforms/desktop-opengl.c
+++ b/src/platforms/desktop-opengl.c
@@ -405,6 +405,11 @@ static void sdl_fix_frame_rate(void) {
 void platform_sound_play(sound_t* sound, int channel) {
     if (audio_disabled) return;
 
+    if (channel >= MIX_CHANNELS) {
+        log_error("Error playing sound: channel %i does not exist", channel);
+        return;
+    }
+
     // Search for a free channel if channel not specified
     if (channel == -1) {
         for (int i = 0; i < MIX_CHANNELS; i++) {
@@ -416,7 +421,7 @@ void platform_sound_play(sound_t* sound, int channel) {
     }
 
     if (channel == -1) {
-        log_error("No free channels available");
+        log_error("Error playing sound: no free channels available");
         return;
     }
 

--- a/src/platforms/desktop-opengl.c
+++ b/src/platforms/desktop-opengl.c
@@ -5,6 +5,7 @@
 #include <SDL_mixer.h>
 #include <GL/glew.h>
 #include <SDL_opengl.h>
+#include <SDL_error.h>
 
 #include "../arguments.h"
 #include "../configuration.h"
@@ -46,6 +47,7 @@ static GLuint index_buffer_object = 0;
 static GLuint texture = 0;
 
 static Mix_Chunk chunks[MIX_CHANNELS];
+static bool audio_enabled = true;
 
 static void sdl_handle_events(void);
 static void sdl_fix_frame_rate(void);
@@ -95,7 +97,10 @@ void platform_init(void) {
     }
 
     if (Mix_OpenAudioDevice(11025, AUDIO_U8, 1, 2048, NULL, 0) < 0) {
-        log_fatal("Error intializing SDL Mixer");
+        log_error("Error intializing SDL Mixer");
+        log_error(SDL_GetError());
+        log_info("Sound playback will be disabled");
+        audio_enabled = false;
     }
 
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, OPENGL_VERSION_MAJOR);
@@ -398,6 +403,8 @@ static void sdl_fix_frame_rate(void) {
 }
 
 void platform_sound_play(sound_t* sound, int channel) {
+    if (!audio_enabled) return;
+
     // Search for a free channel if channel not specified
     if (channel == -1) {
         for (int i = 0; i < MIX_CHANNELS; i++) {

--- a/src/platforms/desktop-opengl.c
+++ b/src/platforms/desktop-opengl.c
@@ -47,7 +47,7 @@ static GLuint index_buffer_object = 0;
 static GLuint texture = 0;
 
 static Mix_Chunk chunks[MIX_CHANNELS];
-static bool audio_enabled = true;
+static bool audio_disabled = false;
 
 static void sdl_handle_events(void);
 static void sdl_fix_frame_rate(void);
@@ -100,7 +100,7 @@ void platform_init(void) {
         log_error("Error intializing SDL Mixer");
         log_error(SDL_GetError());
         log_info("Sound playback will be disabled");
-        audio_enabled = false;
+        audio_disabled = true;
     }
 
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, OPENGL_VERSION_MAJOR);
@@ -403,7 +403,7 @@ static void sdl_fix_frame_rate(void) {
 }
 
 void platform_sound_play(sound_t* sound, int channel) {
-    if (!audio_enabled) return;
+    if (audio_disabled) return;
 
     // Search for a free channel if channel not specified
     if (channel == -1) {

--- a/src/platforms/desktop.c
+++ b/src/platforms/desktop.c
@@ -29,7 +29,7 @@ static int ticks_last_frame;
 static SDL_Rect display_rect;
 
 static Mix_Chunk chunks[MIX_CHANNELS];
-static bool audio_enabled = true;
+static bool audio_disabled = false;
 
 static void sdl_handle_events(void);
 static void sdl_fix_frame_rate(void);
@@ -78,7 +78,7 @@ void platform_init(void) {
         log_error("Error intializing SDL Mixer");
         log_error(SDL_GetError());
         log_info("Sound playback will be disabled");
-        audio_enabled = false;
+        audio_disabled = true;
     }
 
     window = SDL_CreateWindow(
@@ -325,7 +325,7 @@ static void sdl_fix_frame_rate(void) {
 }
 
 void platform_sound_play(sound_t* sound, int channel) {
-    if (!audio_enabled) return;
+    if (audio_disabled) return;
     
     // Search for a free channel if channel not specified
     if (channel == -1) {

--- a/src/platforms/desktop.c
+++ b/src/platforms/desktop.c
@@ -326,6 +326,11 @@ static void sdl_fix_frame_rate(void) {
 
 void platform_sound_play(sound_t* sound, int channel) {
     if (audio_disabled) return;
+
+    if (channel >= MIX_CHANNELS) {
+        log_error("Error playing sound: channel %i does not exist", channel);
+        return;
+    }
     
     // Search for a free channel if channel not specified
     if (channel == -1) {
@@ -338,7 +343,7 @@ void platform_sound_play(sound_t* sound, int channel) {
     }
 
     if (channel == -1) {
-        log_error("No free channels available");
+        log_error("Error playing sound: no free channels available");
         return;
     }
 

--- a/src/platforms/desktop.c
+++ b/src/platforms/desktop.c
@@ -2,6 +2,7 @@
 
 #include <SDL.h>
 #include <SDL_mixer.h>
+#include <SDL_error.h>
 
 #include "../arguments.h"
 #include "../assets.h"
@@ -28,6 +29,7 @@ static int ticks_last_frame;
 static SDL_Rect display_rect;
 
 static Mix_Chunk chunks[MIX_CHANNELS];
+static bool audio_enabled = true;
 
 static void sdl_handle_events(void);
 static void sdl_fix_frame_rate(void);
@@ -73,7 +75,10 @@ void platform_init(void) {
     }
 
     if (Mix_OpenAudioDevice(11025, AUDIO_U8, 1, 2048, NULL, 0) < 0) {
-        log_fatal("Error intializing SDL Mixer");
+        log_error("Error intializing SDL Mixer");
+        log_error(SDL_GetError());
+        log_info("Sound playback will be disabled");
+        audio_enabled = false;
     }
 
     window = SDL_CreateWindow(
@@ -320,6 +325,8 @@ static void sdl_fix_frame_rate(void) {
 }
 
 void platform_sound_play(sound_t* sound, int channel) {
+    if (!audio_enabled) return;
+    
     // Search for a free channel if channel not specified
     if (channel == -1) {
         for (int i = 0; i < MIX_CHANNELS; i++) {

--- a/src/platforms/web-opengl.c
+++ b/src/platforms/web-opengl.c
@@ -43,7 +43,7 @@ static GLuint index_buffer_object = 0;
 static GLuint texture = 0;
 
 static Mix_Chunk chunks[MIX_CHANNELS];
-static bool audio_enabled = true;
+static bool audio_disabled = false;
 
 static void sdl_handle_events(void);
 static void load_shader_program(void);
@@ -89,7 +89,7 @@ void platform_init(void) {
         log_error("Error intializing SDL Mixer");
         log_error(SDL_GetError());
         log_info("Sound playback will be disabled");
-        audio_enabled = false;
+        audio_disabled = true;
     }
 
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, OPENGL_VERSION_MAJOR);
@@ -376,7 +376,7 @@ static void sdl_handle_events(void) {
 }
 
 void platform_sound_play(sound_t* sound, int channel) {
-    if (!audio_enabled) return;
+    if (audio_disabled) return;
 
     // Search for a free channel if channel not specified
     if (channel == -1) {

--- a/src/platforms/web-opengl.c
+++ b/src/platforms/web-opengl.c
@@ -378,6 +378,11 @@ static void sdl_handle_events(void) {
 void platform_sound_play(sound_t* sound, int channel) {
     if (audio_disabled) return;
 
+    if (channel >= MIX_CHANNELS) {
+        log_error("Error playing sound: channel %i does not exist", channel);
+        return;
+    }
+
     // Search for a free channel if channel not specified
     if (channel == -1) {
         for (int i = 0; i < MIX_CHANNELS; i++) {
@@ -389,7 +394,7 @@ void platform_sound_play(sound_t* sound, int channel) {
     }
 
     if (channel == -1) {
-        log_error("No free channels available");
+        log_error("Error playing sound: no free channels available");
         return;
     }
 

--- a/src/platforms/web.c
+++ b/src/platforms/web.c
@@ -295,6 +295,11 @@ static void sdl_handle_events(void) {
 
 void platform_sound_play(sound_t* sound, int channel) {
     if (audio_disabled) return;
+
+    if (channel >= MIX_CHANNELS) {
+        log_error("Error playing sound: channel %i does not exist", channel);
+        return;
+    }
     
     // Search for a free channel if channel not specified
     if (channel == -1) {
@@ -307,7 +312,7 @@ void platform_sound_play(sound_t* sound, int channel) {
     }
 
     if (channel == -1) {
-        log_error("No free channels available");
+        log_error("Error playing sound: no free channels available");
         return;
     }
 

--- a/src/platforms/web.c
+++ b/src/platforms/web.c
@@ -2,6 +2,7 @@
 
 #include <SDL2/SDL.h>
 #include <SDL2/SDL_mixer.h>
+#include <SDL2/SDL_error.h>
 #include <emscripten.h>
 
 #include "../configuration.h"
@@ -23,6 +24,7 @@ static uint32_t* render_buffer = NULL;
 static SDL_Rect display_rect;
 
 static Mix_Chunk chunks[MIX_CHANNELS];
+static bool audio_enabled = true;
 
 static void sdl_handle_events(void);
 
@@ -60,7 +62,10 @@ void platform_init(void) {
     }
 
     if (Mix_OpenAudioDevice(11025, AUDIO_U8, 1, 2048, NULL, 0) < 0) {
-        log_fatal("Error intializing SDL Mixer");
+        log_error("Error intializing SDL Mixer");
+        log_error(SDL_GetError());
+        log_info("Sound playback will be disabled");
+        audio_enabled = false;
     }
 
     window = SDL_CreateWindow(
@@ -289,6 +294,8 @@ static void sdl_handle_events(void) {
 }
 
 void platform_sound_play(sound_t* sound, int channel) {
+    if (!audio_enabled) return;
+    
     // Search for a free channel if channel not specified
     if (channel == -1) {
         for (int i = 0; i < MIX_CHANNELS; i++) {

--- a/src/platforms/web.c
+++ b/src/platforms/web.c
@@ -24,7 +24,7 @@ static uint32_t* render_buffer = NULL;
 static SDL_Rect display_rect;
 
 static Mix_Chunk chunks[MIX_CHANNELS];
-static bool audio_enabled = true;
+static bool audio_disabled = false;
 
 static void sdl_handle_events(void);
 
@@ -65,7 +65,7 @@ void platform_init(void) {
         log_error("Error intializing SDL Mixer");
         log_error(SDL_GetError());
         log_info("Sound playback will be disabled");
-        audio_enabled = false;
+        audio_disabled = true;
     }
 
     window = SDL_CreateWindow(
@@ -294,7 +294,7 @@ static void sdl_handle_events(void) {
 }
 
 void platform_sound_play(sound_t* sound, int channel) {
-    if (!audio_enabled) return;
+    if (audio_disabled) return;
     
     // Search for a free channel if channel not specified
     if (channel == -1) {


### PR DESCRIPTION
More gracefully handle the case where no audio devices are present. This will prevent a crash on Windows.