### PR TITLE
Fix Large Time Delta if Platform Takes a Long Time to Load

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -22,9 +22,9 @@ void core_init(void) {
     log_info("%s", ENGINE_COPYRIGHT);
 
     configuration_init();
-    time_init();
     assets_init();
     platform_init();
+    time_init();
     graphics_init();
     input_init();
     script_init();


### PR DESCRIPTION
# Summary
Fixes issue where the first time delta might be large due to the platform taking a long time to init. This happens in the case of no sound devices being present on the system and SDL takes ~4 seconds to init.

## Fix
The fix is to move `time_init()` after `platform_init()`