### PR TITLE
Features/tidy up builtin shaders

### DIFF
--- a/makefile
+++ b/makefile
@@ -68,7 +68,7 @@ debug:all
 desktop-run: ## Run desktop build
 	./$(BIN)
 
-web:CC=emcc -s USE_SDL=2 -s USE_SDL_MIXER=2 -s USE_GIFLIB=1 -s FULL_ES3=1 -s EXPORTED_FUNCTIONS=_main,_free
+web:CC=emcc -s USE_SDL=2 -s USE_SDL_MIXER=2 -s USE_GIFLIB=1 -s FULL_ES2=1 -s EXPORTED_FUNCTIONS=_main,_free
 web:AR='emar rcu'
 web:RANLIB=emranlib
 web:LIBS=$(LIBLUA) $(LIBZIP) $(LIBCJSON) $(LIBMATHC)

--- a/src/platforms/desktop-opengl.c
+++ b/src/platforms/desktop-opengl.c
@@ -55,8 +55,6 @@ static void sdl_handle_events(void);
 static void sdl_fix_frame_rate(void);
 static void load_shader_program(void);
 
-static const char default_shader[] = "#version 100\nprecision mediump float;uniform sampler2D screen_texture;varying mediump vec2 uv;void main() {gl_FragColor = texture2D(screen_texture, uv);}";
-
 int platform_main(int argc, char* argv[]) {
     if (arguments_check("-v") || arguments_check("--version")) {
        log_info(ENGINE_COPYRIGHT);
@@ -552,13 +550,30 @@ static bool compile_shader(GLuint shader, const GLchar* source) {
     return true;
 }
 
+static const char* default_fragment_shader =
+    "#version 100\n"
+    "precision mediump float;"
+    "uniform sampler2D screen_texture;"
+    "varying mediump vec2 uv;"
+    "void main() {"
+    "    gl_FragColor = texture2D(screen_texture, uv);"
+    "}";
+
+static const char* vertex_shader_source =
+    "#version 100\n"
+    "attribute vec2 position;"
+    "attribute vec2 texture_coordinates;"
+    "varying vec2 uv;"
+    "void main(){"
+    "    uv=texture_coordinates;"
+    "    gl_Position=vec4(position.x,position.y,0,1);"
+    "}";
+
 static void load_shader_program(void) {
     shader_program = glCreateProgram();
     GLuint vertex_shader = glCreateShader(GL_VERTEX_SHADER);
 
     // Vertex shader
-    const GLchar* vertex_shader_source = "#version 100\nattribute vec2 position;attribute vec2 texture_coordinates;varying vec2 uv;void main(){uv=texture_coordinates;gl_Position=vec4(position.x,position.y,0,1);}";
-
     if (!compile_shader(vertex_shader, vertex_shader_source)) {
         log_fatal("Error compiling vertex shader");
     }
@@ -575,7 +590,7 @@ static void load_shader_program(void) {
     }
 
     if (use_default) {
-        if (!compile_shader(fragment_shader, default_shader)) {
+        if (!compile_shader(fragment_shader, default_fragment_shader)) {
             log_fatal("Error compiling default fragment shader");
         }
     }

--- a/src/platforms/web-opengl.c
+++ b/src/platforms/web-opengl.c
@@ -5,7 +5,7 @@
 
 #include <SDL2/SDL.h>
 #include <SDL2/SDL_mixer.h>
-#include <GLES3/gl3.h>
+#include <GLES2/gl2.h>
 #include <SDL2/SDL_opengl.h>
 #include <SDL2/SDL_error.h>
 #include <emscripten.h>
@@ -34,7 +34,7 @@ static SDL_Rect display_rect;
 
 static char* fragment_shader_source = NULL;
 
-#define OPENGL_VERSION_MAJOR 3
+#define OPENGL_VERSION_MAJOR 2
 #define OPENGL_VERSION_MINOR 0
 
 static GLuint shader_program;

--- a/src/platforms/web-opengl.c
+++ b/src/platforms/web-opengl.c
@@ -55,8 +55,6 @@ static void sdl_handle_events(void);
 static void sdl_fix_frame_rate(void);
 static void load_shader_program(void);
 
-static const char default_shader[] = "#version 100\nprecision mediump float;uniform sampler2D screen_texture;varying mediump vec2 uv;void main() {gl_FragColor = texture2D(screen_texture, uv);}";
-
 int platform_main(int argc, char* argv[]) {
     core_init();
     emscripten_set_main_loop(core_main_loop, 0, 1);
@@ -534,13 +532,31 @@ static bool compile_shader(GLuint shader, const GLchar* source) {
     return true;
 }
 
+static const char* default_fragment_shader =
+    "#version 100\n"
+    "precision mediump float;"
+    "uniform sampler2D screen_texture;"
+    "varying mediump vec2 uv;"
+    "void main() {"
+    "    gl_FragColor = texture2D(screen_texture, uv);"
+    "}";
+
+static const char* vertex_shader_source =
+    "#version 100\n"
+    "attribute vec2 position;"
+    "attribute vec2 texture_coordinates;"
+    "varying vec2 uv;"
+    "void main(){"
+    "    uv=texture_coordinates;"
+    "    gl_Position=vec4(position.x,position.y,0,1);"
+    "}";
+
+
 static void load_shader_program(void) {
     shader_program = glCreateProgram();
     GLuint vertex_shader = glCreateShader(GL_VERTEX_SHADER);
 
     // Vertex shader
-    const GLchar* vertex_shader_source = "#version 100\nattribute vec2 position;attribute vec2 texture_coordinates;varying vec2 uv;void main(){uv=texture_coordinates;gl_Position=vec4(position.x,position.y,0,1);}";
-
     if (!compile_shader(vertex_shader, vertex_shader_source)) {
         log_fatal("Error compiling vertex shader");
     }
@@ -557,7 +573,7 @@ static void load_shader_program(void) {
     }
 
     if (use_default) {
-        if (!compile_shader(fragment_shader, default_shader)) {
+        if (!compile_shader(fragment_shader, default_fragment_shader)) {
             log_fatal("Error compiling default fragment shader");
         }
     }

--- a/src/platforms/web-opengl.c
+++ b/src/platforms/web-opengl.c
@@ -551,7 +551,6 @@ static const char* vertex_shader_source =
     "    gl_Position=vec4(position.x,position.y,0,1);"
     "}";
 
-
 static void load_shader_program(void) {
     shader_program = glCreateProgram();
     GLuint vertex_shader = glCreateShader(GL_VERTEX_SHADER);


### PR DESCRIPTION
# Summary
Move web-opengl back down to OpenGL ES2 and make built-in shaders more readable.