### PR TITLE
Fixes/fix crash on resolution change

### DIFF
--- a/library/graphics.lua
+++ b/library/graphics.lua
@@ -59,4 +59,9 @@ function graphics.set_global_palette_color(index, r, g, b) end
 --- @param height integer  Resolution height
 function graphics.set_resolution(width, height) end
 
+--- Get render buffer resolution.
+--- @return integer Resolution width
+--- @return integer Resolution height
+function graphics.get_resolution() end
+
 return graphics

--- a/src/console.c
+++ b/src/console.c
@@ -344,6 +344,13 @@ static bool handle_key_up(event_t* event) {
 }
 
 bool console_handle_event(event_t* event) {
+    // Toggle console
+    if (event->type == EVENT_KEYDOWN && event->key.code == KEYCODE_GRAVE) {
+        console_buffer_toggle();
+        return true;
+    }
+
+    // Don't handle events if console is hidden
     if (!visible) return false;
 
     switch (event->type) {

--- a/src/console.c
+++ b/src/console.c
@@ -164,7 +164,9 @@ static void load_input_history(void) {
 }
 
 static void scroll_up(void) {
-    const int max_lines = (config->resolution.height / 2) / 8 - 1;
+    int height;
+    graphics_resolution_get(NULL, &height);
+    const int max_lines = (height / 2) / 8 - 1;
 
     if (output->count > max_lines) {
         output_buffer_offset--;
@@ -176,7 +178,9 @@ static void scroll_up(void) {
 }
 
 static void scroll_down(void) {
-    const int max_lines = (config->resolution.height / 2) / 8 - 1;
+    int height;
+    graphics_resolution_get(NULL, &height);
+    const int max_lines = (height / 2) / 8 - 1;
 
     if (output->count > max_lines) {
         output_buffer_offset = fminf(output_buffer_offset + 1, 0);
@@ -387,11 +391,15 @@ void console_draw(void) {
     palette[1] = config->console.colors.foreground;
     graphics_transparent_color_set(config->console.colors.transparent);
 
+    int width;
+    int height;
+    graphics_resolution_get(&width, &height);
+
     rect_t console_rect = {
         0,
         0,
-        config->resolution.width,
-        (config->resolution.height / 2) / 8 * 8
+        width,
+        (height / 2) / 8 * 8
     };
 
     draw_filled_rectangle(

--- a/src/core.c
+++ b/src/core.c
@@ -91,7 +91,7 @@ static void handle_events() {
             continue;
         }
 
-        if (console_handle_event(&event)) return;
+        if (console_handle_event(&event)) continue;
 
         input_handle_event(&event);
     }

--- a/src/core.c
+++ b/src/core.c
@@ -91,13 +91,6 @@ static void handle_events() {
             continue;
         }
 
-        if (event.type == EVENT_KEYDOWN) {
-            if (event.key.code == KEYCODE_GRAVE) {
-                console_buffer_toggle();
-                return;
-            }
-        }
-
         if (console_handle_event(&event)) return;
 
         input_handle_event(&event);

--- a/src/core.c
+++ b/src/core.c
@@ -91,6 +91,8 @@ static void handle_events() {
             continue;
         }
 
+        if (platform_handle_event(&event)) continue;
+
         if (console_handle_event(&event)) continue;
 
         input_handle_event(&event);

--- a/src/event.h
+++ b/src/event.h
@@ -23,7 +23,8 @@ typedef enum {
     EVENT_MOUSEWHEEL,
     EVENT_CONTROLLERBUTTONDOWN,
     EVENT_CONTROLLERBUTTONUP,
-    EVENT_CONTROLLERAXISMOTION
+    EVENT_CONTROLLERAXISMOTION,
+    EVENT_GRAPHICSRESOLUTIONCHANGED
 } event_type_t;
 
 typedef struct {
@@ -420,6 +421,12 @@ typedef struct {
     float value;
 } controller_axis_event_t;
 
+typedef struct {
+    event_type_t type;
+    int width;
+    int height;
+} graphics_resolution_change_event_t;
+
 typedef union {
     event_type_t type;
     common_event_t common;
@@ -429,6 +436,7 @@ typedef union {
     mouse_wheel_event_t wheel;
     controller_button_event_t controller_button;
     controller_axis_event_t controller_axis;
+    graphics_resolution_change_event_t graphics_resolution_change;
 } event_t;
 
 /**

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -3,6 +3,7 @@
 #include <string.h>
 
 #include "configuration.h"
+#include "event.h"
 #include "graphics.h"
 #include "log.h"
 
@@ -283,21 +284,33 @@ void graphics_blit(texture_t* source_texture, texture_t* destination_texture, re
 
 void graphics_resolution_set(int width, int height) {
     graphics_texture_free(render_texture);
-
-    render_texture = graphics_texture_new(
-        config->resolution.width,
-        config->resolution.height,
-        NULL
-    );
+    render_texture = graphics_texture_new(width, height, NULL);
 
     if (!render_texture) {
         log_fatal("Failed to create frame buffer");
     }
 
+    // Post event on successfully changing resolution
+    event_t event;
+    event.type = EVENT_GRAPHICSRESOLUTIONCHANGED;
+    event.graphics_resolution_change.width = width;
+    event.graphics_resolution_change.height = height;
+    event_post(&event);
+
     clip_rect.x = 0;
     clip_rect.y = 0;
-    clip_rect.width = config->resolution.width;
-    clip_rect.height = config->resolution.height;
+    clip_rect.width = width;
+    clip_rect.height = height;
+}
+
+void graphics_resolution_get(int* width, int* height) {
+    if (width) {
+        *width = render_texture->width;
+    }
+
+    if (height) {
+        *height = render_texture->height;
+    }
 }
 
 void graphics_clipping_rectangle_set(rect_t* rect) {

--- a/src/graphics.h
+++ b/src/graphics.h
@@ -218,6 +218,14 @@ void graphics_blit(
 void graphics_resolution_set(int width, int height);
 
 /**
+ * Gets render buffer resolution.
+ *
+ * @param width Width of render buffer in pixels. Can be NULL.
+ * @param height Heigh of render buffer in pixels. Can be NULL.
+ */
+void graphics_resolution_get(int* width, int* height);
+
+/**
  * Sets clipping rectangle which defines drawable area.
  *
  * @param x Rect top left x-coordinate

--- a/src/modules/graphics.c
+++ b/src/modules/graphics.c
@@ -67,8 +67,10 @@ static int modules_graphics_blit(lua_State* L) {
     int sh = texture->height;
     int dx = 0;
     int dy = 0;
-    int dw = config->resolution.width;
-    int dh = config->resolution.height;
+    int dw;
+    int dh;
+
+    graphics_resolution_get(&dw, &dh);
 
     if (arg_count == 3) {
         dx = (int)luaL_checknumber(L, 2);
@@ -205,12 +207,21 @@ static int modules_graphics_resolution_set(lua_State* L) {
 
     lua_pop(L, -1);
 
-    config->resolution.width = width;
-    config->resolution.height = height;
-
     graphics_resolution_set(width, height);
 
     return 0;
+}
+
+static int modules_graphics_resolution_get(lua_State* L) {
+    int width = 0;
+    int height = 0;
+
+    graphics_resolution_get(&width, &height);
+
+    lua_pushinteger(L, width);
+    lua_pushinteger(L, height);
+
+    return 2;
 }
 
 static const struct luaL_Reg modules_graphics_functions[] = {
@@ -222,6 +233,7 @@ static const struct luaL_Reg modules_graphics_functions[] = {
     {"set_transparent_color", modules_graphics_transparent_color_set},
     {"set_global_palette_color", modules_graphics_palette_color_set},
     {"set_resolution", modules_graphics_resolution_set},
+    {"get_resolution", modules_graphics_resolution_get},
     {NULL, NULL}
 };
 

--- a/src/modules/graphics.c
+++ b/src/modules/graphics.c
@@ -212,6 +212,12 @@ static int modules_graphics_resolution_set(lua_State* L) {
     return 0;
 }
 
+/**
+ * Get render buffer resolution.
+ * @function get_resolution
+ * @treturn[1] integer Resolution width
+ * @treturn[2] integer Resolution height
+ */
 static int modules_graphics_resolution_get(lua_State* L) {
     int width = 0;
     int height = 0;

--- a/src/platform.h
+++ b/src/platform.h
@@ -12,6 +12,7 @@
 
 #include <stdbool.h>
 
+#include "event.h"
 #include "sounds.h"
 #include "threads.h"
 
@@ -47,6 +48,11 @@ void platform_update(void);
  * Draw system. Called at the end of an engine update cycle.
  */
 void platform_draw(void);
+
+/**
+ * Handle given event.
+ */
+bool platform_handle_event(event_t* event);
 
 /**
  * Plays given sound.

--- a/src/platforms/desktop-opengl.c
+++ b/src/platforms/desktop-opengl.c
@@ -54,6 +54,9 @@ static bool audio_disabled = false;
 static void sdl_handle_events(void);
 static void sdl_fix_frame_rate(void);
 static void load_shader_program(void);
+static void opengl_init(int width, int height);
+static void opengl_destroy(void);
+static void render_buffer_set(int width, int height);
 
 int platform_main(int argc, char* argv[]) {
     if (arguments_check("-v") || arguments_check("--version")) {
@@ -89,8 +92,10 @@ void platform_init(void) {
 
     log_info(buffer);
 
-    const int window_width = config->resolution.width * 3;
-    const int window_height = config->resolution.height * 3;
+    const int width = config->resolution.width;
+    const int height = config->resolution.height;
+    const int window_width = width * 3;
+    const int window_height = height * 3;
 
     if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_GAMECONTROLLER) != 0) {
         log_fatal("Error initializing SDL");
@@ -125,12 +130,36 @@ void platform_init(void) {
         log_fatal("Error creating OpenGL context");
     }
 
-    render_buffer = calloc(config->resolution.width * config->resolution.height, sizeof(uint32_t));
+    render_buffer_set(width, height);
 
-    if (!render_buffer) {
-        log_fatal("Error creating frame buffer.");
-    }
+    opengl_init(width, height);
 
+    SDL_ShowCursor(SDL_DISABLE);
+}
+
+void platform_destroy(void) {
+    opengl_destroy();
+    free(render_buffer);
+    SDL_DestroyWindow(window);
+    Mix_Quit();
+    SDL_Quit();
+}
+
+void platform_reload(void) {
+    opengl_destroy();
+    Mix_HaltChannel(-1);
+    Mix_Volume(-1, MIX_MAX_VOLUME);
+
+    render_buffer_set(config->resolution.width, config->resolution.height);
+    opengl_init(config->resolution.width, config->resolution.height);
+}
+
+void platform_update(void) {
+    sdl_handle_events();
+    sdl_fix_frame_rate();
+}
+
+static void opengl_init(int width, int height) {
     glewExperimental = GL_TRUE;
     GLenum glewError = glewInit();
     if (glewError != GLEW_OK) {
@@ -165,42 +194,24 @@ void platform_init(void) {
     // Create texture
     glGenTextures(1, &texture);
     glBindTexture(GL_TEXTURE_2D, texture);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, config->resolution.width, config->resolution.height, 0, GL_RGBA, GL_UNSIGNED_BYTE, render_buffer);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, render_buffer);
 
     // Set texture paramters
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-
-    display_rect.x = 0;
-    display_rect.y = 0;
-    display_rect.w = window_width;
-    display_rect.h = window_height;
-
-    SDL_ShowCursor(SDL_DISABLE);
 }
 
-void platform_destroy(void) {
+static void opengl_destroy(void) {
+    glDeleteTextures(1, &texture);
+    glDeleteBuffers(1, &index_buffer_object);
+    glDeleteBuffers(1, &vertex_buffer_object);
     glDeleteProgram(shader_program);
-    if (fragment_shader_source) free(fragment_shader_source);
-    free(render_buffer);
-    SDL_DestroyWindow(window);
-    Mix_Quit();
-    SDL_Quit();
-}
 
-void platform_reload(void) {
-    glDeleteProgram(shader_program);
-    if (fragment_shader_source) free(fragment_shader_source);
-    load_shader_program();
-    Mix_HaltChannel(-1);
-    Mix_Volume(-1, MIX_MAX_VOLUME);
-}
-
-void platform_update(void) {
-    sdl_handle_events();
-    sdl_fix_frame_rate();
+    if (fragment_shader_source) {
+        free(fragment_shader_source);
+    }
 }
 
 void platform_draw(void) {
@@ -213,13 +224,17 @@ void platform_draw(void) {
     }
 
     // Maintain aspect ratio and center in window
+    int width;
+    int height;
+    graphics_resolution_get(&width, &height);
+
     int window_width;
     int window_height;
 
     SDL_GetWindowSize(window, &window_width, &window_height);
 
     float window_aspect = window_width / (float)window_height;
-    float buffer_aspect = config->resolution.width / (float)config->resolution.height * config->display.aspect;
+    float buffer_aspect = width / (float)height * config->display.aspect;
 
     display_rect.w = window_width;
     display_rect.h = window_height;
@@ -282,13 +297,48 @@ void platform_draw(void) {
     SDL_GL_SwapWindow(window);
 }
 
+bool platform_handle_event(event_t* event) {
+    if (event->type == EVENT_GRAPHICSRESOLUTIONCHANGED) {
+        int width = event->graphics_resolution_change.width;
+        int height = event->graphics_resolution_change.height;
+
+        opengl_destroy();
+        render_buffer_set(width, height);
+        opengl_init(width, height);
+
+        return true;
+    }
+
+    return false;
+}
+
+static void render_buffer_set(int width, int height) {
+    if (sizeof(render_buffer) == width * height * sizeof(uint32_t)) return;
+
+    // Free if not NULL
+    if (render_buffer) {
+        free(render_buffer);
+        render_buffer = NULL;
+    }
+
+    render_buffer = calloc(width * height, sizeof(uint32_t));
+
+    if (!render_buffer) {
+        log_fatal("Error creating frame buffer.");
+    }
+}
+
 static void sdl_handle_events(void) {
     SDL_Event sdl_event;
     event_t event;
     SDL_GameController* controller = NULL;
 
-    float aspect_width = config->resolution.width / (float)display_rect.w;
-    float aspect_height = config->resolution.height / (float)display_rect.h;
+    int width;
+    int height;
+    graphics_resolution_get(&width, &height);
+
+    float aspect_width = width / (float)display_rect.w;
+    float aspect_height = height / (float)display_rect.h;
 
     while (SDL_PollEvent(&sdl_event)) {
         switch (sdl_event.type) {
@@ -321,8 +371,8 @@ static void sdl_handle_events(void) {
                 event.motion.motion_x = (sdl_event.motion.xrel) * aspect_width;
                 event.motion.motion_y = (sdl_event.motion.yrel) * aspect_height;
 
-                event.motion.x = clamp(event.motion.x, 0, config->resolution.width - 1);
-                event.motion.y = clamp(event.motion.y, 0, config->resolution.height - 1);
+                event.motion.x = clamp(event.motion.x, 0, width - 1);
+                event.motion.y = clamp(event.motion.y, 0, height - 1);
 
                 event_post(&event);
                 break;

--- a/src/platforms/desktop.c
+++ b/src/platforms/desktop.c
@@ -120,8 +120,8 @@ void platform_init(void) {
         renderer,
         SDL_PIXELFORMAT_RGBA32,
         SDL_TEXTUREACCESS_STREAMING,
-        config->resolution.width,
-        config->resolution.height
+        width,
+        height
     );
 
     if (!render_buffer_texture) {

--- a/src/platforms/desktop.c
+++ b/src/platforms/desktop.c
@@ -35,6 +35,7 @@ static bool audio_disabled = false;
 
 static void sdl_handle_events(void);
 static void sdl_fix_frame_rate(void);
+static void render_buffer_set(int width, int height);
 
 int platform_main(int argc, char* argv[]) {
     if (arguments_check("-v") || arguments_check("--version")) {
@@ -69,8 +70,10 @@ void platform_init(void) {
 
     log_info(buffer);
 
-    const int window_width = config->resolution.width * 3;
-    const int window_height = config->resolution.height * 3;
+    const int width = config->resolution.width;
+    const int height = config->resolution.height;
+    const int window_width = width * 3;
+    const int window_height = height * 3;
 
     if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_GAMECONTROLLER) != 0) {
         log_fatal("Error initializing SDL");
@@ -111,11 +114,7 @@ void platform_init(void) {
         SDL_BLENDMODE_BLEND
     );
 
-    render_buffer = calloc(config->resolution.width * config->resolution.height, sizeof(uint32_t));
-
-    if (!render_buffer) {
-        log_fatal("Error creating frame buffer.");
-    }
+    render_buffer_set(width, height);
 
     render_buffer_texture = SDL_CreateTexture(
         renderer,
@@ -166,13 +165,17 @@ void platform_draw(void) {
     }
 
     // Maintain aspect ratio and center in window
+    int width;
+    int height;
+    graphics_resolution_get(&width, &height);
+
     int window_width;
     int window_height;
 
     SDL_GetWindowSize(window, &window_width, &window_height);
 
     float window_aspect = window_width / (float)window_height;
-    float buffer_aspect = config->resolution.width / (float)config->resolution.height * config->display.aspect;
+    float buffer_aspect = width / (float)height * config->display.aspect;
 
     display_rect.w = window_width;
     display_rect.h = window_height;
@@ -206,13 +209,60 @@ void platform_draw(void) {
     SDL_RenderPresent(renderer);
 }
 
+bool platform_handle_event(event_t* event) {
+    if (event->type == EVENT_GRAPHICSRESOLUTIONCHANGED) {
+        int width = event->graphics_resolution_change.width;
+        int height = event->graphics_resolution_change.height;
+
+        render_buffer_set(width, height);
+
+        SDL_DestroyTexture(render_buffer_texture);
+
+        render_buffer_texture = SDL_CreateTexture(
+            renderer,
+            SDL_PIXELFORMAT_RGBA32,
+            SDL_TEXTUREACCESS_STREAMING,
+            width,
+            height
+        );
+
+        if (!render_buffer_texture) {
+            log_fatal("Error creating SDL frame buffer texture");
+        }
+
+        return true;
+    }
+
+    return false;
+}
+
+static void render_buffer_set(int width, int height) {
+    if (sizeof(render_buffer) == width * height * sizeof(uint32_t)) return;
+
+    // Free if not NULL
+    if (render_buffer) {
+        free(render_buffer);
+        render_buffer = NULL;
+    }
+
+    render_buffer = calloc(width * height, sizeof(uint32_t));
+
+    if (!render_buffer) {
+        log_fatal("Error creating frame buffer.");
+    }
+}
+
 static void sdl_handle_events(void) {
     SDL_Event sdl_event;
     event_t event;
     SDL_GameController* controller = NULL;
 
-    float aspect_width = config->resolution.width / (float)display_rect.w;
-    float aspect_height = config->resolution.height / (float)display_rect.h;
+    int width;
+    int height;
+    graphics_resolution_get(&width, &height);
+
+    float aspect_width = width / (float)display_rect.w;
+    float aspect_height = height / (float)display_rect.h;
 
     while (SDL_PollEvent(&sdl_event)) {
         switch (sdl_event.type) {
@@ -245,8 +295,8 @@ static void sdl_handle_events(void) {
                 event.motion.motion_x = (sdl_event.motion.xrel) * aspect_width;
                 event.motion.motion_y = (sdl_event.motion.yrel) * aspect_height;
 
-                event.motion.x = clamp(event.motion.x, 0, config->resolution.width - 1);
-                event.motion.y = clamp(event.motion.y, 0, config->resolution.height - 1);
+                event.motion.x = clamp(event.motion.x, 0, width - 1);
+                event.motion.y = clamp(event.motion.y, 0, height - 1);
 
                 event_post(&event);
                 break;

--- a/src/platforms/web-opengl.c
+++ b/src/platforms/web-opengl.c
@@ -154,12 +154,6 @@ void platform_update(void) {
 }
 
 static void opengl_init(int width, int height) {
-    glewExperimental = GL_TRUE;
-    GLenum glewError = glewInit();
-    if (glewError != GLEW_OK) {
-        log_fatal("Error initializing GLEW");
-    }
-
     load_shader_program();
 
     glClearColor(0.0f, 0.0f, 0.0f, 1.0f);

--- a/src/platforms/web.c
+++ b/src/platforms/web.c
@@ -112,8 +112,8 @@ void platform_init(void) {
         renderer,
         SDL_PIXELFORMAT_RGBA32,
         SDL_TEXTUREACCESS_STREAMING,
-        config->resolution.width,
-        config->resolution.height
+        width,
+        height
     );
 
     if (!render_buffer_texture) {

--- a/src/platforms/web.c
+++ b/src/platforms/web.c
@@ -34,6 +34,7 @@ static bool audio_disabled = false;
 
 static void sdl_handle_events(void);
 static void sdl_fix_frame_rate(void);
+static void render_buffer_set(int width, int height);
 
 int platform_main(int argc, char* argv[]) {
     core_init();
@@ -61,8 +62,10 @@ void platform_init(void) {
 
     log_info(buffer);
 
-    const int window_width = config->resolution.width * 3;
-    const int window_height = config->resolution.height * 3;
+    const int width = config->resolution.width;
+    const int height = config->resolution.height;
+    const int window_width = width * 3;
+    const int window_height = height * 3;
 
     if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_GAMECONTROLLER) != 0) {
         log_fatal("Error initializing SDL");
@@ -103,11 +106,7 @@ void platform_init(void) {
         SDL_BLENDMODE_BLEND
     );
 
-    render_buffer = calloc(config->resolution.width * config->resolution.height, sizeof(uint32_t));
-
-    if (!render_buffer) {
-        log_fatal("Error creating frame buffer.");
-    }
+    render_buffer_set(width, height);
 
     render_buffer_texture = SDL_CreateTexture(
         renderer,
@@ -158,13 +157,17 @@ void platform_draw(void) {
     }
 
     // Maintain aspect ratio and center in window
+    int width;
+    int height;
+    graphics_resolution_get(&width, &height);
+
     int window_width;
     int window_height;
 
     SDL_GetWindowSize(window, &window_width, &window_height);
 
     float window_aspect = window_width / (float)window_height;
-    float buffer_aspect = config->resolution.width / (float)config->resolution.height * config->display.aspect;
+    float buffer_aspect = width / (float)height * config->display.aspect;
 
     display_rect.w = window_width;
     display_rect.h = window_height;
@@ -186,6 +189,8 @@ void platform_draw(void) {
         render_texture->width * sizeof(uint32_t)
     );
 
+    SDL_RenderClear(renderer);
+
     SDL_RenderCopy(
         renderer,
         render_buffer_texture,
@@ -196,13 +201,60 @@ void platform_draw(void) {
     SDL_RenderPresent(renderer);
 }
 
+bool platform_handle_event(event_t* event) {
+    if (event->type == EVENT_GRAPHICSRESOLUTIONCHANGED) {
+        int width = event->graphics_resolution_change.width;
+        int height = event->graphics_resolution_change.height;
+
+        render_buffer_set(width, height);
+
+        SDL_DestroyTexture(render_buffer_texture);
+
+        render_buffer_texture = SDL_CreateTexture(
+            renderer,
+            SDL_PIXELFORMAT_RGBA32,
+            SDL_TEXTUREACCESS_STREAMING,
+            width,
+            height
+        );
+
+        if (!render_buffer_texture) {
+            log_fatal("Error creating SDL frame buffer texture");
+        }
+
+        return true;
+    }
+
+    return false;
+}
+
+static void render_buffer_set(int width, int height) {
+    if (sizeof(render_buffer) == width * height * sizeof(uint32_t)) return;
+
+    // Free if not NULL
+    if (render_buffer) {
+        free(render_buffer);
+        render_buffer = NULL;
+    }
+
+    render_buffer = calloc(width * height, sizeof(uint32_t));
+
+    if (!render_buffer) {
+        log_fatal("Error creating frame buffer.");
+    }
+}
+
 static void sdl_handle_events(void) {
     SDL_Event sdl_event;
     event_t event;
     SDL_GameController* controller = NULL;
 
-    float aspect_width = config->resolution.width / (float)display_rect.w;
-    float aspect_height = config->resolution.height / (float)display_rect.h;
+    int width;
+    int height;
+    graphics_resolution_get(&width, &height);
+
+    float aspect_width = width / (float)display_rect.w;
+    float aspect_height = height / (float)display_rect.h;
 
     while (SDL_PollEvent(&sdl_event)) {
         switch (sdl_event.type) {
@@ -235,8 +287,8 @@ static void sdl_handle_events(void) {
                 event.motion.motion_x = (sdl_event.motion.xrel) * aspect_width;
                 event.motion.motion_y = (sdl_event.motion.yrel) * aspect_height;
 
-                event.motion.x = clamp(event.motion.x, 0, config->resolution.width - 1);
-                event.motion.y = clamp(event.motion.y, 0, config->resolution.height - 1);
+                event.motion.x = clamp(event.motion.x, 0, width - 1);
+                event.motion.y = clamp(event.motion.y, 0, height - 1);
 
                 event_post(&event);
                 break;


### PR DESCRIPTION
## Summary
Fixes crash when changing resolution programmatically. The core issue was that the color buffer being sent to the platform wasn't being resized and would result in overflowing the color buffer.

## Changes
- Added an event for when the graphics resolution changes.
- Added the ability for platforms to handle events.
- Added API to graphics module to get resolution. Removed config as source of truth.