### PR TITLE
Fixes/fix blurry hidpi

### DIFF
--- a/notes/build.md
+++ b/notes/build.md
@@ -1,5 +1,9 @@
 # Build
 
+## Dependencies
+
+Platforms using SDL have a min required version of 2.26.0
+
 ## Profiling
 
 1. Add `-pg -no-pie` to DFLAGS

--- a/src/modules/platforms/desktop.h
+++ b/src/modules/platforms/desktop.h
@@ -24,6 +24,8 @@
 #include "../../configuration.h"
 #include "../../graphics.h"
 
+#include "../../platforms/extensions/sdl-extensions.h"
+
 static SDL_Window* window_ = NULL;
 
 /**
@@ -77,7 +79,7 @@ static int modules_desktop_window_size_set(lua_State* L) {
     int w = luaL_checknumber(L, 1);
     int h = luaL_checknumber(L, 2);
 
-    SDL_SetWindowSize(window_, w, h);
+    SDL_SetWindowSizeInPixels(window_, w, h);
 
     return 0;
 }
@@ -91,7 +93,7 @@ static int modules_desktop_window_size_set(lua_State* L) {
 static int modules_desktop_window_size_get(lua_State* L) {
     int w;
     int h;
-    SDL_GetWindowSize(window_, &w, &h);
+    SDL_GetWindowSizeInPixels(window_, &w, &h);
 
     lua_pushinteger(L, w);
     lua_pushinteger(L, h);

--- a/src/platforms/desktop-opengl.c
+++ b/src/platforms/desktop-opengl.c
@@ -379,7 +379,7 @@ static void sdl_init(void) {
         SDL_WINDOWPOS_CENTERED,
         width * default_window_scale,
         height * default_window_scale,
-        SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE
+        SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE  | SDL_WINDOW_ALLOW_HIGHDPI
     );
 
     if (!window) {

--- a/src/platforms/desktop-opengl.c
+++ b/src/platforms/desktop-opengl.c
@@ -9,6 +9,8 @@
 #include <SDL_opengl.h>
 #include <SDL_error.h>
 
+#include "extensions/sdl-extensions.h"
+
 #include "../arguments.h"
 #include "../configuration.h"
 #include "../core.h"
@@ -124,7 +126,7 @@ void platform_draw(void) {
     int window_width;
     int window_height;
 
-    SDL_GetWindowSize(window, &window_width, &window_height);
+    SDL_GetWindowSizeInPixels(window, &window_width, &window_height);
 
     float window_aspect = window_width / (float)window_height;
     float buffer_aspect = width / (float)height * config->display.aspect;

--- a/src/platforms/desktop-opengl.c
+++ b/src/platforms/desktop-opengl.c
@@ -360,6 +360,8 @@ void platform_thread_condition_notify(thread_condition_t* condition) {
 }
 
 static void sdl_init(void) {
+    SDL_SetHint(SDL_HINT_WINDOWS_DPI_AWARENESS , "permonitorv2");
+
     if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_GAMECONTROLLER) != 0) {
         log_fatal("Error initializing SDL");
     }

--- a/src/platforms/desktop.c
+++ b/src/platforms/desktop.c
@@ -315,6 +315,8 @@ void platform_thread_condition_notify(thread_condition_t* condition) {
 }
 
 static void sdl_init(void) {
+    SDL_SetHint(SDL_HINT_WINDOWS_DPI_AWARENESS , "permonitorv2");
+
     if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_GAMECONTROLLER) != 0) {
         log_fatal("Error initializing SDL");
     }

--- a/src/platforms/desktop.c
+++ b/src/platforms/desktop.c
@@ -6,6 +6,8 @@
 #include <SDL_mixer.h>
 #include <SDL_error.h>
 
+#include "extensions/sdl-extensions.h"
+
 #include "../arguments.h"
 #include "../assets.h"
 #include "../configuration.h"
@@ -96,7 +98,7 @@ void platform_draw(void) {
     int window_width;
     int window_height;
 
-    SDL_GetWindowSize(window, &window_width, &window_height);
+    SDL_GetWindowSizeInPixels(window, &window_width, &window_height);
 
     float window_aspect = window_width / (float)window_height;
     float buffer_aspect = width / (float)height * config->display.aspect;
@@ -332,12 +334,18 @@ static void sdl_init(void) {
         SDL_WINDOWPOS_CENTERED,
         width * default_window_scale,
         height * default_window_scale,
-        SDL_WINDOW_RESIZABLE
+        SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI
     );
 
     if (!window) {
         log_fatal("Error creating SDL window");
     }
+
+    SDL_SetWindowSizeInPixels(
+        window,
+        width * default_window_scale,
+        height * default_window_scale
+    );
 
     // Create SDL renderer
     renderer = SDL_CreateRenderer(

--- a/src/platforms/extensions/sdl-extensions.h
+++ b/src/platforms/extensions/sdl-extensions.h
@@ -1,0 +1,20 @@
+#ifndef SDL_EXTENSIONS_H
+#define SDL_EXTENSIONS_H
+
+#include <SDL.h>
+
+float SDL_GetWindowPixelScale(SDL_Window* window) {
+    int sw, pw;
+    SDL_GetWindowSize(window, &sw, NULL);
+    SDL_GetWindowSizeInPixels(window, &pw, NULL);
+
+    return (float)sw / pw;
+}
+
+void SDL_SetWindowSizeInPixels(SDL_Window* window, int w, int h) {
+    float pixel_scale = SDL_GetWindowPixelScale(window);
+
+    SDL_SetWindowSize(window, w * pixel_scale, h * pixel_scale);
+}
+
+#endif

--- a/src/platforms/extensions/sdl-extensions.h
+++ b/src/platforms/extensions/sdl-extensions.h
@@ -3,6 +3,12 @@
 
 #include <SDL.h>
 
+/**
+ * Gets the scale of a window's pixel.
+ *
+ * @param window The window to query
+ * @return Scale as a ratio of logical to pixel units.
+ */
 float SDL_GetWindowPixelScale(SDL_Window* window) {
     int sw, pw;
     SDL_GetWindowSize(window, &sw, NULL);
@@ -11,10 +17,17 @@ float SDL_GetWindowPixelScale(SDL_Window* window) {
     return (float)sw / pw;
 }
 
-void SDL_SetWindowSizeInPixels(SDL_Window* window, int w, int h) {
+/**
+ * Sets the size of a window's client area in pixels.
+ *
+ * @param window The window to change
+ * @param width Width of window in pixels
+ * @param height Height of window in pixels
+ */
+void SDL_SetWindowSizeInPixels(SDL_Window* window, int width, int height) {
     float pixel_scale = SDL_GetWindowPixelScale(window);
 
-    SDL_SetWindowSize(window, w * pixel_scale, h * pixel_scale);
+    SDL_SetWindowSize(window, width * pixel_scale, height * pixel_scale);
 }
 
 #endif

--- a/src/platforms/web-opengl.c
+++ b/src/platforms/web-opengl.c
@@ -10,6 +10,8 @@
 #include <SDL2/SDL_error.h>
 #include <emscripten.h>
 
+#include "extensions/sdl-extensions.h"
+
 #include "../configuration.h"
 #include "../core.h"
 #include "../event.h"
@@ -117,7 +119,7 @@ void platform_draw(void) {
     int window_width;
     int window_height;
 
-    SDL_GetWindowSize(window, &window_width, &window_height);
+    SDL_GetWindowSizeInPixels(window, &window_width, &window_height);
 
     float window_aspect = window_width / (float)window_height;
     float buffer_aspect = width / (float)height * config->display.aspect;

--- a/src/platforms/web-opengl.c
+++ b/src/platforms/web-opengl.c
@@ -370,7 +370,7 @@ static void sdl_init(void) {
         SDL_WINDOWPOS_CENTERED,
         width * default_window_scale,
         height * default_window_scale,
-        SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE
+        SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI
     );
 
     if (!window) {

--- a/src/platforms/web.c
+++ b/src/platforms/web.c
@@ -324,7 +324,7 @@ static void sdl_init(void) {
         SDL_WINDOWPOS_CENTERED,
         width * default_window_scale,
         height * default_window_scale,
-        SDL_WINDOW_RESIZABLE
+        SDL_WINDOW_RESIZABLE  | SDL_WINDOW_ALLOW_HIGHDPI
     );
 
     if (!window) {

--- a/src/platforms/web.c
+++ b/src/platforms/web.c
@@ -7,6 +7,8 @@
 #include <SDL2/SDL_error.h>
 #include <emscripten.h>
 
+#include "extensions/sdl-extensions.h"
+
 #include "../configuration.h"
 #include "../core.h"
 #include "../event.h"
@@ -88,7 +90,7 @@ void platform_draw(void) {
     int window_width;
     int window_height;
 
-    SDL_GetWindowSize(window, &window_width, &window_height);
+    SDL_GetWindowSizeInPixels(window, &window_width, &window_height);
 
     float window_aspect = window_width / (float)window_height;
     float buffer_aspect = width / (float)height * config->display.aspect;


### PR DESCRIPTION
## Summary

Fixes blurriness related to HiDPI monitors and logical scaling versus pixel scaling. The fix here was to always work in pixels and disregard HiDPI window scaling.

## Testing

- Windows 11 - 3840x2160 150% scaling
- Windows 11 - 1920x1080 100% scaling
- Ubuntu 22.04.5 LTS - 3840x2160 200% scaling
- Ubuntu 22.04.5 LTS - 1920x1080 100% scaling
- MacOS Sequoia 15.6 - 3840x2160 200% scaling