### PR TITLE
Increase chunk size to 512 to fix web audio issues

### DIFF
--- a/src/platforms/desktop-opengl.c
+++ b/src/platforms/desktop-opengl.c
@@ -544,7 +544,7 @@ static void sdl_pixels_resize(int width, int height) {
 }
 
 static void mixer_init(void) {
-    if (Mix_OpenAudioDevice(11025, AUDIO_U8, 1, 256, NULL, 0) < 0) {
+    if (Mix_OpenAudioDevice(11025, AUDIO_U8, 1, 512, NULL, 0) < 0) {
         log_error("Error intializing SDL Mixer");
         log_error(SDL_GetError());
         log_info("Sound playback will be disabled");

--- a/src/platforms/desktop.c
+++ b/src/platforms/desktop.c
@@ -522,7 +522,7 @@ static void sdl_pixels_resize(int width, int height) {
 }
 
 static void mixer_init(void) {
-    if (Mix_OpenAudioDevice(11025, AUDIO_U8, 1, 256, NULL, 0) < 0) {
+    if (Mix_OpenAudioDevice(11025, AUDIO_U8, 1, 512, NULL, 0) < 0) {
         log_error("Error intializing SDL Mixer");
         log_error(SDL_GetError());
         log_info("Sound playback will be disabled");

--- a/src/platforms/web-opengl.c
+++ b/src/platforms/web-opengl.c
@@ -535,7 +535,7 @@ static void sdl_pixels_resize(int width, int height) {
 }
 
 static void mixer_init(void) {
-    if (Mix_OpenAudioDevice(11025, AUDIO_U8, 1, 256, NULL, 0) < 0) {
+    if (Mix_OpenAudioDevice(11025, AUDIO_U8, 1, 512, NULL, 0) < 0) {
         log_error("Error intializing SDL Mixer");
         log_error(SDL_GetError());
         log_info("Sound playback will be disabled");

--- a/src/platforms/web.c
+++ b/src/platforms/web.c
@@ -506,7 +506,7 @@ static void sdl_pixels_resize(int width, int height) {
 }
 
 static void mixer_init(void) {
-    if (Mix_OpenAudioDevice(11025, AUDIO_U8, 1, 256, NULL, 0) < 0) {
+    if (Mix_OpenAudioDevice(11025, AUDIO_U8, 1, 512, NULL, 0) < 0) {
         log_error("Error intializing SDL Mixer");
         log_error(SDL_GetError());
         log_info("Sound playback will be disabled");


### PR DESCRIPTION
## Summary
Issue with crackling audio in web builds was due to lowering the audio chunk size to 256. Bring it back up to 512 fixes the crackling audio issue.

## Testing
- Firefox
- Chrome 
- DuckDuckGo