### PR TITLE
Features/move clipping to draw

### DIFF
--- a/demos/3d_dot_party/pico.lua
+++ b/demos/3d_dot_party/pico.lua
@@ -30,7 +30,7 @@ function circfill(x, y, r, col)
 end
 
 function clip(x, y, w, h)
-    graphics.set_clipping_rectangle(x, y, w, h)
+    draw.set_clipping_rectangle(x, y, w, h)
 end
 
 --- clear screen; col = clear color

--- a/src/console.c
+++ b/src/console.c
@@ -411,7 +411,7 @@ void console_draw(void) {
         config->console.colors.background
     );
 
-    graphics_clipping_rectangle_set(&console_rect);
+    graphics_draw_clipping_rectangle_set(&console_rect);
 
     int line = 0;
     const int max_lines = (console_rect.height / 8) - 1;
@@ -448,7 +448,7 @@ void console_draw(void) {
     palette[1] = foreground;
     graphics_draw_transparent_color_set(transparent_color);
 
-    graphics_clipping_rectangle_set(NULL);
+    graphics_draw_clipping_rectangle_set(NULL);
 }
 
 void console_buffer_write(const char* line) {

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -10,8 +10,6 @@
 static texture_t* render_texture = NULL;
 static uint32_t palette[256];
 
-static rect_t clip_rect;
-
 void graphics_init(void) {
     log_info("graphics init");
 
@@ -25,12 +23,8 @@ void graphics_init(void) {
         log_fatal("Failed to create frame buffer");
     }
 
-    clip_rect.x = 0;
-    clip_rect.y = 0;
-    clip_rect.width = config->resolution.width;
-    clip_rect.height = config->resolution.height;
-
     graphics_draw_palette_reset();
+    graphics_draw_clipping_rectangle_set(NULL);
 }
 
 void graphics_destroy(void) {
@@ -58,9 +52,6 @@ void graphics_palette_clear(void) {
 }
 
 void graphics_pixel_set(int x, int y, color_t color) {
-    if (x < clip_rect.x || x >= clip_rect.x + clip_rect.width) return;
-    if (y < clip_rect.y || y >= clip_rect.y + clip_rect.height) return;
-
     graphics_texture_pixel_set(render_texture, x, y, color);
 }
 
@@ -159,10 +150,7 @@ void graphics_resolution_set(int width, int height) {
     event.graphics_resolution_change.height = height;
     event_post(&event);
 
-    clip_rect.x = 0;
-    clip_rect.y = 0;
-    clip_rect.width = width;
-    clip_rect.height = height;
+    graphics_draw_clipping_rectangle_set(NULL);
 }
 
 void graphics_resolution_get(int* width, int* height) {
@@ -173,23 +161,4 @@ void graphics_resolution_get(int* width, int* height) {
     if (height) {
         *height = graphics_texture_height_get(render_texture);
     }
-}
-
-void graphics_clipping_rectangle_set(rect_t* rect) {
-    rect_t default_rect = {
-        0,
-        0,
-        graphics_texture_width_get(render_texture),
-        graphics_texture_height_get(render_texture)
-    };
-
-    if (!rect) {
-        rect = &default_rect;
-    }
-
-    clip_rect = *rect;
-}
-
-rect_t* graphics_clipping_rectangle_get(void) {
-    return &clip_rect;
 }

--- a/src/graphics.h
+++ b/src/graphics.h
@@ -107,21 +107,4 @@ void graphics_resolution_set(int width, int height);
  */
 void graphics_resolution_get(int* width, int* height);
 
-/**
- * Sets clipping rectangle which defines drawable area.
- *
- * @param x Rect top left x-coordinate
- * @param y Rect top left y-coordinate
- * @param width Rect width
- * @param height Rect height
- */
-void graphics_clipping_rectangle_set(rect_t* rect);
-
-/**
- * Gets clipping rectangle which defines the drawable area.
- *
- * @return rect_t Clipping rectangle
- */
-rect_t* graphics_clipping_rectangle_get(void);
-
 #endif

--- a/src/graphics/draw.c
+++ b/src/graphics/draw.c
@@ -15,28 +15,6 @@
 static color_t draw_palette[256];
 static color_t transparent_color = 0;
 
-color_t* graphics_draw_palette_get(void) {
-    return draw_palette;
-}
-
-void graphics_draw_palette_set(uint32_t* new_palette) {
-    memmove(draw_palette, new_palette, sizeof(draw_palette));
-}
-
-void graphics_draw_palette_reset(void) {
-    for (int i = 0; i < 256; i++) {
-        draw_palette[i] = i;
-    }
-}
-
-void graphics_draw_transparent_color_set(int color) {
-    transparent_color = color;
-}
-
-int graphics_draw_transparent_color_get(void) {
-    return transparent_color;
-}
-
 void graphics_draw_pixel(texture_t* destination, int x, int y, color_t color) {
     if (color == transparent_color) return;
 
@@ -700,4 +678,26 @@ void graphics_draw_texture(texture_t* destination, texture_t* source, int x, int
         &dest_rect,
         draw_blit_func
     );
+}
+
+color_t* graphics_draw_palette_get(void) {
+    return draw_palette;
+}
+
+void graphics_draw_palette_set(uint32_t* new_palette) {
+    memmove(draw_palette, new_palette, sizeof(draw_palette));
+}
+
+void graphics_draw_palette_reset(void) {
+    for (int i = 0; i < 256; i++) {
+        draw_palette[i] = i;
+    }
+}
+
+void graphics_draw_transparent_color_set(int color) {
+    transparent_color = color;
+}
+
+int graphics_draw_transparent_color_get(void) {
+    return transparent_color;
 }

--- a/src/graphics/draw.c
+++ b/src/graphics/draw.c
@@ -14,9 +14,15 @@
 
 static color_t draw_palette[256];
 static color_t transparent_color = 0;
+static rect_t clip_rect;
 
 void graphics_draw_pixel(texture_t* destination, int x, int y, color_t color) {
+    // Don't draw if transparent
     if (color == transparent_color) return;
+
+    // Don't draw if outside clipping rectangle
+    if (x < clip_rect.x || x >= clip_rect.x + clip_rect.width) return;
+    if (y < clip_rect.y || y >= clip_rect.y + clip_rect.height) return;
 
     graphics_texture_pixel_set(destination, x, y, color);
 }
@@ -700,4 +706,25 @@ void graphics_draw_transparent_color_set(int color) {
 
 int graphics_draw_transparent_color_get(void) {
     return transparent_color;
+}
+
+void graphics_draw_clipping_rectangle_set(rect_t* rect) {
+    texture_t* render_texture = graphics_render_texture_get();
+
+    rect_t default_rect = {
+        0,
+        0,
+        graphics_texture_width_get(render_texture),
+        graphics_texture_height_get(render_texture)
+    };
+
+    if (!rect) {
+        rect = &default_rect;
+    }
+
+    clip_rect = *rect;
+}
+
+rect_t* graphics_draw_clipping_rectangle_get(void) {
+    return &clip_rect;
 }

--- a/src/graphics/draw.h
+++ b/src/graphics/draw.h
@@ -324,4 +324,21 @@ void graphics_draw_transparent_color_set(int color);
  */
 int graphics_draw_transparent_color_get(void);
 
+/**
+ * Sets clipping rectangle which defines drawable area.
+ *
+ * @param x Rect top left x-coordinate
+ * @param y Rect top left y-coordinate
+ * @param width Rect width
+ * @param height Rect height
+ */
+void graphics_draw_clipping_rectangle_set(rect_t* rect);
+
+/**
+ * Gets clipping rectangle which defines the drawable area.
+ *
+ * @return rect_t Clipping rectangle
+ */
+rect_t* graphics_draw_clipping_rectangle_get(void);
+
 #endif

--- a/src/graphics/draw.h
+++ b/src/graphics/draw.h
@@ -4,39 +4,6 @@
 #include "types.h"
 
 /**
- * Get draw palette.
- *
- * @return Palette as a 256 color array.
- */
-color_t* graphics_draw_palette_get(void);
-
-/**
- * Set draw palette.
- *
- * @param palette 256 color array.
- */
-void graphics_draw_palette_set(uint32_t* palette);
-
-/**
- * Reset all draw palette values.
- */
-void graphics_draw_palette_reset(void);
-
-/**
- * Set transparent color.
- *
- * @param color Color to set as transparent. A value of -1 is no transparency.
- */
-void graphics_draw_transparent_color_set(int color);
-
-/**
- * Get transparent color.
- *
- * @return int Transparent color. A value of -1 is no transparency.
- */
-int graphics_draw_transparent_color_get(void);
-
-/**
  * Draw pixel at x, y with given color
  *
  * @param destination Texture to draw to
@@ -323,5 +290,38 @@ void graphics_draw_textured_triangle(texture_t* destination, int x0, int y0, flo
  * @param height Source height
  */
 void graphics_draw_texture(texture_t* destination, texture_t* source, int x, int y, int width, int height);
+
+/**
+ * Get draw palette.
+ *
+ * @return Palette as a 256 color array.
+ */
+color_t* graphics_draw_palette_get(void);
+
+/**
+ * Set draw palette.
+ *
+ * @param palette 256 color array.
+ */
+void graphics_draw_palette_set(uint32_t* palette);
+
+/**
+ * Reset all draw palette values.
+ */
+void graphics_draw_palette_reset(void);
+
+/**
+ * Set transparent color.
+ *
+ * @param color Color to set as transparent. A value of -1 is no transparency.
+ */
+void graphics_draw_transparent_color_set(int color);
+
+/**
+ * Get transparent color.
+ *
+ * @return int Transparent color. A value of -1 is no transparency.
+ */
+int graphics_draw_transparent_color_get(void);
 
 #endif

--- a/src/modules/draw.c
+++ b/src/modules/draw.c
@@ -506,6 +506,36 @@ static int modules_draw_transparent_color_set(lua_State* L) {
 }
 
 /**
+ * Sets clipping rectangle which defines drawable area.
+ * @function set_clipping_rectangle
+ * @tparam integer x Rect top left x-coordinate
+ * @tparam integer y Rect top left y-coordinate
+ * @tparam integer width Rect width
+ * @tparam integer height Rect height
+ */
+static int modules_draw_clipping_rectangle_set(lua_State* L) {
+    int arg_count = lua_gettop(L);
+
+    if (arg_count == 0) {
+        graphics_draw_clipping_rectangle_set(NULL);
+        return 0;
+    }
+
+    int x = (int)luaL_checknumber(L, 1);
+    int y = (int)luaL_checknumber(L, 2);
+    int width = (int)luaL_checknumber(L, 3);
+    int height = (int)luaL_checknumber(L, 4);
+
+    lua_pop(L, -1);
+
+    rect_t clip_rect = {x, y, width, height};
+
+    graphics_draw_clipping_rectangle_set(&clip_rect);
+
+    return 0;
+}
+
+/**
  * Get current render texture for drawing
  * @function get_render_texture
  * @return texture.texture Current drawing render texture
@@ -551,6 +581,7 @@ static const struct luaL_Reg modules_draw_functions[] = {
     {"texture", modules_draw_texture},
     {"set_palette_color", modules_draw_palette_color_set},
     {"set_transparent_color", modules_draw_transparent_color_set},
+    {"set_clipping_rectangle", modules_draw_clipping_rectangle_set},
     {"get_render_texture", modules_draw_render_texture_get},
     {"set_render_texture", modules_draw_render_texture_set},
     {NULL, NULL}

--- a/src/modules/graphics.c
+++ b/src/modules/graphics.c
@@ -100,36 +100,6 @@ static int modules_graphics_blit(lua_State* L) {
 }
 
 /**
- * Sets clipping rectangle which defines drawable area.
- * @function set_clipping_rectangle
- * @tparam integer x Rect top left x-coordinate
- * @tparam integer y Rect top left y-coordinate
- * @tparam integer width Rect width
- * @tparam integer height Rect height
- */
-static int modules_graphics_clipping_rectangle_set(lua_State* L) {
-    int arg_count = lua_gettop(L);
-
-    if (arg_count == 0) {
-        graphics_clipping_rectangle_set(NULL);
-        return 0;
-    }
-
-    int x = (int)luaL_checknumber(L, 1);
-    int y = (int)luaL_checknumber(L, 2);
-    int width = (int)luaL_checknumber(L, 3);
-    int height = (int)luaL_checknumber(L, 4);
-
-    lua_pop(L, -1);
-
-    rect_t clip_rect = {x, y, width, height};
-
-    graphics_clipping_rectangle_set(&clip_rect);
-
-    return 0;
-}
-
-/**
  * Gets render texture.
  * @function get_render_texture
  * @treturn texture.texture Render texture userdata.
@@ -203,7 +173,6 @@ static int modules_graphics_resolution_get(lua_State* L) {
 static const struct luaL_Reg modules_graphics_functions[] = {
     {"set_pixel", modules_graphics_pixel_set},
     {"blit", modules_graphics_blit},
-    {"set_clipping_rectangle", modules_graphics_clipping_rectangle_set},
     {"get_render_texture", modules_graphics_render_texture_get},
     {"set_global_palette_color", modules_graphics_palette_color_set},
     {"set_resolution", modules_graphics_resolution_set},

--- a/src/renderers/raycaster.c
+++ b/src/renderers/raycaster.c
@@ -663,10 +663,6 @@ static float sprite_depth = FLT_MAX;
  * @param dy Destination y-coordinate
  */
 static void sprite_depth_blit_func(texture_t* source_texture, texture_t* destination_texture, int sx, int sy, int dx, int dy) {
-    rect_t* clip_rect = graphics_clipping_rectangle_get();
-    if (dx < clip_rect->x || dx >= clip_rect->x + clip_rect->width) return;
-    if (dy < clip_rect->y || dy >= clip_rect->y + clip_rect->height) return;
-
     float depth = sprite_depth;
     float d = renderer_depth_buffer_pixel_get(active_renderer, dx, dy);
     if (d <= depth) return;


### PR DESCRIPTION
## Summary
Move clipping rectangle ownership to draw module.

## Breaking Changes
- `graphics.set_clipping_rectangle()` moved to `draw.set_clipping_rectangle()`