### PR TITLE
Features/draw affine texture

### DIFF
--- a/library/draw.lua
+++ b/library/draw.lua
@@ -119,7 +119,12 @@ function draw.filled_triangle(x0, y0, x1, y1, x2, y2, color) end
 --- @param texture texture  Texture to map
 function draw.textured_triangle(x0, y0, u0, v0, x1, y1, u1, v1, x2, y2, u2, v2, texture) end
 
---- Draw texture
+--- Draw texture with affine transformation.
+--- @param texture texture  Texture to draw
+--- @param matrix matrix3  Affine transformation to use when drawing
+function draw.texture(texture, matrix) end
+
+--- Draw texture.
 --- @param texture texture  Texture to draw
 --- @param x integer  Texture x-coordinate
 --- @param y integer  Texture y-coordinate
@@ -135,6 +140,13 @@ function draw.set_palette_color(index, color) end
 --- Sets transparent color.
 --- @param color integer  Color set set as transparent.
 function draw.set_transparent_color(color) end
+
+--- Sets clipping rectangle which defines drawable area.
+--- @param x integer  Rect top left x-coordinate
+--- @param y integer  Rect top left y-coordinate
+--- @param width integer  Rect width
+--- @param height integer  Rect height
+function draw.set_clipping_rectangle(x, y, width, height) end
 
 --- Get current render texture for drawing
 --- @return  texture.texture Current drawing render texture

--- a/src/graphics/draw.c
+++ b/src/graphics/draw.c
@@ -759,7 +759,7 @@ void graphics_draw_affine_texture(texture_t* destination, texture_t* source, mfl
     mfloat_t uv0[VEC3_SIZE];
     mfloat_t uv1[VEC3_SIZE];
     vec3(uv0, min[0], min[1], 1);
-    vec3(uv1, max[0], min[1], 1);
+    vec3(uv1, max[0] + 1, min[1], 1);
     vec3_multiply_mat3(uv0, uv0, inverse);
     vec3_multiply_mat3(uv1, uv1, inverse);
 
@@ -812,7 +812,7 @@ void graphics_draw_affine_texture(texture_t* destination, texture_t* source, mfl
                 destination,
                 x0, y,
                 u0, v0,
-                x1 - 1, y,
+                x1, y,
                 u1, v1,
                 source
             );

--- a/src/graphics/draw.c
+++ b/src/graphics/draw.c
@@ -702,6 +702,105 @@ void graphics_draw_texture(texture_t* destination, texture_t* source, int x, int
     );
 }
 
+void graphics_draw_affine_texture(texture_t* destination, texture_t* source, mfloat_t* matrix) {
+    mfloat_t p0[VEC3_SIZE] = {0, 0, 1};
+    mfloat_t p1[VEC3_SIZE] = {0, 1, 1};
+    mfloat_t p2[VEC3_SIZE] = {1, 1, 1};
+    mfloat_t p3[VEC3_SIZE] = {1, 0, 1};
+
+    // Transform UV space
+    vec3_multiply_mat3(p0, p0, matrix);
+    vec3_multiply_mat3(p1, p1, matrix);
+    vec3_multiply_mat3(p2, p2, matrix);
+    vec3_multiply_mat3(p3, p3, matrix);
+
+    // Determine bounds
+    mfloat_t min[VEC3_SIZE];
+    mfloat_t max[VEC3_SIZE];
+    vec3_assign(min, p0);
+    vec3_assign(max, p0);
+
+    vec3_min(min, min, p1);
+    vec3_min(min, min, p2);
+    vec3_min(min, min, p3);
+
+    vec3_max(max, max, p1);
+    vec3_max(max, max, p2);
+    vec3_max(max, max, p3);
+
+    vec3_floor(min, min);
+    vec3_floor(max, max);
+
+    // Get screen to UV transformation
+    mfloat_t inverse[MAT3_SIZE];
+    mat3_inverse(inverse, matrix);
+
+    // Get UV coordinates for first scanline
+    mfloat_t uv0[VEC3_SIZE];
+    mfloat_t uv1[VEC3_SIZE];
+    mfloat_t inc[VEC3_SIZE];
+
+    vec3(uv0, min[0], min[1], 1);
+    vec3(uv1, max[0], min[1], 1);
+
+    float one_pixel_vertical = 1.0f / graphics_texture_height_get(source);
+    vec3(inc, 0, 1.0f + one_pixel_vertical, 0);
+
+    vec3_multiply_mat3(uv0, uv0, inverse);
+    vec3_multiply_mat3(uv1, uv1, inverse);
+    vec3_multiply_mat3(inc, inc, inverse);
+
+    int max_height = graphics_texture_height_get(destination);
+    int max_width = graphics_texture_width_get(destination);
+
+    for (int y = min[1]; y < max[1]; y++) {
+        if (y >= max_height) break;
+
+        if (y >= 0) {
+            // Clip scanline to screen
+            mfloat_t d[VEC3_SIZE];
+            vec3_subtract(d, uv1, uv0);
+
+            float x0 = min[0];
+            float x1 = max[0];
+            float u0 = uv0[0];
+            float v0 = uv0[1];
+            float u1 = uv1[0];
+            float v1 = uv1[1];
+
+            // Clip left
+            if (x0 < 0) {
+                float t = x0 / (x1 - x0);
+                x0 = 0;
+                u0 = u0 - d[0] * t;
+                v0 = v0 - d[1] * t;
+            }
+
+            // Clip right
+            float w = max_width - 1;
+            if (x1 > w) {
+                float t = (x1 - w) / (x1 - x0);
+                x1 = w;
+                u1 = u1 - d[0] * t;
+                v1 = v1 - d[1] * t;
+            }
+
+            // Draw scanline
+            graphics_draw_textured_line(
+                destination,
+                x0, y,
+                u0, v0,
+                x1 - 1, y,
+                u1, v1,
+                source
+            );
+        }
+
+        vec3_add(uv0, uv0, inc);
+        vec3_add(uv1, uv1, inc);
+    }
+}
+
 color_t* graphics_draw_palette_get(void) {
     return draw_palette;
 }

--- a/src/graphics/draw.h
+++ b/src/graphics/draw.h
@@ -1,6 +1,8 @@
 #ifndef GRAPHICS_DRAW_H
 #define GRAPHICS_DRAW_H
 
+#include <mathc/mathc.h>
+
 #include "types.h"
 
 /**
@@ -290,6 +292,15 @@ void graphics_draw_textured_triangle(texture_t* destination, int x0, int y0, flo
  * @param height Source height
  */
 void graphics_draw_texture(texture_t* destination, texture_t* source, int x, int y, int width, int height);
+
+/**
+ * Draw source texture to destination texture using given matrix.
+ *
+ * @param destination Texture to draw to
+ * @param source Texture to draw
+ * @param matrix Affine transformation to apply to texture when drawing
+ */
+void graphics_draw_affine_texture(texture_t* destination, texture_t* source, mfloat_t* matrix);
 
 /**
  * Get draw palette.

--- a/src/modules/draw.c
+++ b/src/modules/draw.c
@@ -8,6 +8,7 @@
 #include <lua/lualib.h>
 
 #include "draw.h"
+#include "matrix3.h"
 #include "texture.h"
 #include "../assets.h"
 #include "../graphics.h"
@@ -445,6 +446,19 @@ static int modules_draw_textured_triangle(lua_State* L) {
  */
 static int modules_draw_texture(lua_State* L) {
     texture_t* texture = luaL_checktexture(L, 1);
+
+    if (lua_gettop(L) == 2) {
+        mfloat_t* matrix = luaL_checkmatrix3(L, 2);
+
+        graphics_draw_affine_texture(
+            draw_render_texture_get(),
+            texture,
+            matrix
+        );
+
+        return 0;
+    }
+
     int x = (int)luaL_checknumber(L, 2);
     int y = (int)luaL_checknumber(L, 3);
     int width = (int)luaL_optnumber(L, 4, graphics_texture_width_get(texture));

--- a/src/modules/draw.c
+++ b/src/modules/draw.c
@@ -436,7 +436,14 @@ static int modules_draw_textured_triangle(lua_State* L) {
 }
 
 /**
- * Draw texture
+ * Draw texture with affine transformation.
+ * @function texture
+ * @tparam texture.texture texture Texture to draw
+ * @tparam matrix3.matrix3 matrix Affine transformation to use when drawing
+ */
+
+/**
+ * Draw texture.
  * @function texture
  * @tparam texture.texture texture Texture to draw
  * @tparam integer x Texture x-coordinate


### PR DESCRIPTION
![screenshot_20250917114006](https://github.com/user-attachments/assets/2db1a88b-2fa9-4e4f-9129-7b5b242d24ae)

## Summary
Add support for drawing textures with an affiine transformations.

## Lua changes
Lua draw module updated. Now drawing a texture can take either coords + size or a matrix3 
`draw.texture(texture, matrix3)`