### PR TITLE
Support floor division for vectors

### DIFF
--- a/src/modules/vector2.c
+++ b/src/modules/vector2.c
@@ -249,6 +249,38 @@ static int modules_vector2_divide(lua_State* L) {
     return 1;
 }
 
+static int modules_vector2_floor_divide(lua_State* L) {
+    mfloat_t* v0 = luaL_checkvector2(L, 1);
+
+    // Scalar division
+    if (lua_isnumber(L, 2)) {
+        float f = luaL_checknumber(L, 2);
+
+        lua_settop(L, 0);
+
+        mfloat_t result[VEC2_SIZE];
+        vec2_divide_f(result, v0, f);
+        vec2_floor(result, result);
+
+        lua_newvector2(L, result[0], result[1]);
+
+        return 1;
+    }
+
+    // Component-wise division
+    mfloat_t* v1 = luaL_checkvector2(L, 2);
+
+    lua_settop(L, 0);
+
+    mfloat_t result[VEC2_SIZE];
+    vec2_divide(result, v0, v1);
+    vec2_floor(result, result);
+
+    lua_newvector2(L, result[0], result[1]);
+
+    return 1;
+}
+
 /**
  * Returns a vector made from snapping the components to given resolution.
  * @function snap
@@ -835,6 +867,7 @@ static const struct luaL_Reg modules_vector2_meta_functions[] = {
     {"__sub", modules_vector2_subtract},
     {"__mul", modules_vector2_multiply},
     {"__div", modules_vector2_divide},
+    {"__idiv", modules_vector2_floor_divide},
     {"__unm", modules_vector2_negative},
     {"__eq", modules_vector2_equal},
     {NULL, NULL}

--- a/src/modules/vector3.c
+++ b/src/modules/vector3.c
@@ -283,6 +283,38 @@ static int modules_vector3_divide(lua_State* L) {
     return 1;
 }
 
+static int modules_vector3_floor_divide(lua_State* L) {
+    mfloat_t* v0 = luaL_checkvector3(L, 1);
+
+    // Scalar division
+    if (lua_isnumber(L, 2)) {
+        float f = luaL_checknumber(L, 2);
+
+        lua_settop(L, 0);
+
+        mfloat_t result[VEC3_SIZE];
+        vec3_divide_f(result, v0, f);
+        vec3_floor(result, result);
+
+        lua_newvector3(L, result[0], result[1], result[2]);
+
+        return 1;
+    }
+
+    // Component-wise division
+    mfloat_t* v1 = luaL_checkvector3(L, 2);
+
+    lua_settop(L, 0);
+
+    mfloat_t result[VEC3_SIZE];
+    vec3_divide(result, v0, v1);
+    vec3_floor(result, result);
+
+    lua_newvector3(L, result[0], result[1], result[2]);
+
+    return 1;
+}
+
 /**
  * Returns a vector made from snapping the components to given resolution.
  * @function snap
@@ -915,6 +947,7 @@ static const struct luaL_Reg modules_vector3_meta_functions[] = {
     {"__sub", modules_vector3_subtract},
     {"__mul", modules_vector3_multiply},
     {"__div", modules_vector3_divide},
+    {"__idiv", modules_vector3_floor_divide},
     {"__unm", modules_vector3_negative},
     {"__eq", modules_vector3_equal},
     {NULL, NULL}

--- a/src/modules/vector4.c
+++ b/src/modules/vector4.c
@@ -277,6 +277,38 @@ static int modules_vector4_divide(lua_State* L) {
     return 1;
 }
 
+static int modules_vector4_floor_divide(lua_State* L) {
+    mfloat_t* v0 = luaL_checkvector4(L, 1);
+
+    // Scalar division
+    if (lua_isnumber(L, 2)) {
+        float f = luaL_checknumber(L, 2);
+
+        lua_settop(L, 0);
+
+        mfloat_t result[VEC4_SIZE];
+        vec4_divide_f(result, v0, f);
+        vec4_floor(result, result);
+
+        lua_newvector4(L, result[0], result[1], result[2], result[3]);
+
+        return 1;
+    }
+
+    // Component-wise division
+    mfloat_t* v1 = luaL_checkvector4(L, 2);
+
+    lua_settop(L, 0);
+
+    mfloat_t result[VEC4_SIZE];
+    vec4_divide(result, v0, v1);
+    vec4_floor(result, result);
+
+    lua_newvector4(L, result[0], result[1], result[2], result[3]);
+
+    return 1;
+}
+
 /**
  * Returns a vector made from snapping the components to given resolution.
  * @function snap
@@ -689,6 +721,7 @@ static const struct luaL_Reg modules_vector4_meta_functions[] = {
     {"__sub", modules_vector4_subtract},
     {"__mul", modules_vector4_multiply},
     {"__div", modules_vector4_divide},
+    {"__idiv", modules_vector4_floor_divide},
     {"__unm", modules_vector4_negative},
     {"__eq", modules_vector4_equal},
     {NULL, NULL}


### PR DESCRIPTION
# Summary
Adds floor division support for vector types.

`vector3.new(1, 3, 5) // 2`