### PR TITLE
Add dummy values to metatables for better autocomplete

### DIFF
--- a/src/modules/gamecontroller.c
+++ b/src/modules/gamecontroller.c
@@ -197,40 +197,6 @@ static int gamecontroller_button_axes(lua_State*L) {
     return 1;
 }
 
-static int error_readonly(lua_State* L) {
-    luaL_error(L, "attempt to update a read-only table");
-    return 0;
-}
-
-static int make_readonly(lua_State* L) {
-    int base = lua_gettop(L);
-
-    // Given table to make read-only
-    luaL_checktype(L, base, LUA_TTABLE); // table
-
-    // Proxy table
-    lua_newtable(L);
-
-    // Metatable
-    lua_newtable(L);
-
-    // Set __index field of metatable to given table
-    lua_pushvalue(L, base);
-    lua_setfield(L, -2, "__index");
-
-    // Set __newindex field of metatable to error function
-    lua_pushcfunction(L, error_readonly);
-    lua_setfield(L, -2, "__newindex");
-
-    // Set proxy table metatable to metatable
-    lua_setmetatable(L, -2);
-
-    // Remove given table leaving proxy on top
-    lua_remove(L, base);
-
-    return 1;
-}
-
 static const struct luaL_Reg modules_gamecontroller_functions[] = {
     {"button", modules_gamecontroller_button_get},
     {"axis", modules_gamecontroller_axis_get},

--- a/src/modules/luautils.c
+++ b/src/modules/luautils.c
@@ -1,0 +1,52 @@
+#include <lua/lua.h>
+#include <lua/lauxlib.h>
+#include <lua/lualib.h>
+
+#include "luautils.h"
+
+static int error_readonly(lua_State* L) {
+    luaL_error(L, "attempt to update a read-only table");
+    return 0;
+}
+
+int make_readonly(lua_State* L) {
+    int base = lua_gettop(L);
+
+    // Given table to make read-only
+    luaL_checktype(L, base, LUA_TTABLE); // table
+
+    // Proxy table
+    lua_newtable(L);
+
+    // Metatable
+    lua_newtable(L);
+
+    // Set __index field of metatable to given table
+    lua_pushvalue(L, base);
+    lua_setfield(L, -2, "__index");
+
+    // Set __newindex field of metatable to error function
+    lua_pushcfunction(L, error_readonly);
+    lua_setfield(L, -2, "__newindex");
+
+    // Set proxy table metatable to metatable
+    lua_setmetatable(L, -2);
+
+    // Remove given table leaving proxy on top
+    lua_remove(L, base);
+
+    return 1;
+}
+
+void lua_setdummyfields(lua_State* L, const char* field_names[]) {
+    if (!lua_istable(L, -1)) {
+        luaL_error(L, "Missing table to set fields for");
+        return;
+    }
+
+    const char** name;
+    for (name = field_names; *name; name++) {
+        lua_pushinteger(L, 0);
+        lua_setfield(L, -2, *name);
+    }
+}

--- a/src/modules/luautils.h
+++ b/src/modules/luautils.h
@@ -1,0 +1,13 @@
+#ifndef LUAUTILS_H
+#define LUAUTILS_H
+
+#include <lua/lua.h>
+
+int make_readonly(lua_State* L);
+
+/**
+ * Set dummy fields for autocomplete.
+ */
+void lua_setdummyfields(lua_State* L, const char* field_names[]);
+
+#endif

--- a/src/modules/matrix2.c
+++ b/src/modules/matrix2.c
@@ -11,6 +11,7 @@
 
 #include <mathc/mathc.h>
 
+#include "luautils.h"
 #include "matrix2.h"
 #include "vector2.h"
 
@@ -507,6 +508,14 @@ static int modules_matrix2_meta_tostring(lua_State* L) {
     return 1;
 }
 
+static const char* modules_matrix2_fields[] = {
+    "m11",
+    "m21",
+    "m12",
+    "m22",
+    NULL
+};
+
 static const struct luaL_Reg modules_matrix2_meta_functions[] = {
     {"__index", modules_matrix2_meta_index},
     {"__newindex", modules_matrix2_meta_newindex},
@@ -521,6 +530,7 @@ int luaopen_matrix2(lua_State* L) {
 
     luaL_newmetatable(L, "matrix2");
     luaL_setfuncs(L, modules_matrix2_meta_functions, 0);
+    lua_setdummyfields(L, modules_matrix2_fields);
 
     lua_pushstring(L, "__gc");
     lua_pushcfunction(L, modules_matrix2_gc);
@@ -530,6 +540,7 @@ int luaopen_matrix2(lua_State* L) {
 
     luaL_newmetatable(L, "matrix2_nogc");
     luaL_setfuncs(L, modules_matrix2_meta_functions, 0);
+    lua_setdummyfields(L, modules_matrix2_fields);
 
     lua_pop(L, 1);
 

--- a/src/modules/matrix3.c
+++ b/src/modules/matrix3.c
@@ -11,6 +11,7 @@
 
 #include <mathc/mathc.h>
 
+#include "luautils.h"
 #include "matrix3.h"
 #include "quaternion.h"
 #include "vector3.h"
@@ -646,6 +647,19 @@ static int modules_matrix3_meta_tostring(lua_State* L) {
     return 1;
 }
 
+static const char* modules_matrix3_fields[] = {
+    "m11",
+    "m21",
+    "m31",
+    "m12",
+    "m22",
+    "m32",
+    "m13",
+    "m23",
+    "m33",
+    NULL
+};
+
 static const struct luaL_Reg modules_matrix3_meta_functions[] = {
     {"__index", modules_matrix3_meta_index},
     {"__newindex", modules_matrix3_meta_newindex},
@@ -660,6 +674,7 @@ int luaopen_matrix3(lua_State* L) {
 
     luaL_newmetatable(L, "matrix3");
     luaL_setfuncs(L, modules_matrix3_meta_functions, 0);
+    lua_setdummyfields(L, modules_matrix3_fields);
 
     lua_pushstring(L, "__gc");
     lua_pushcfunction(L, modules_matrix3_gc);
@@ -669,6 +684,7 @@ int luaopen_matrix3(lua_State* L) {
 
     luaL_newmetatable(L, "matrix3_nogc");
     luaL_setfuncs(L, modules_matrix3_meta_functions, 0);
+    lua_setdummyfields(L, modules_matrix3_fields);
 
     lua_pop(L, 1);
 

--- a/src/modules/matrix4.c
+++ b/src/modules/matrix4.c
@@ -11,6 +11,7 @@
 
 #include <mathc/mathc.h>
 
+#include "luautils.h"
 #include "matrix4.h"
 #include "quaternion.h"
 #include "vector3.h"
@@ -962,6 +963,26 @@ static int modules_matrix4_meta_tostring(lua_State* L) {
     return 1;
 }
 
+static const char* modules_matrix4_fields[] = {
+    "m11",
+    "m21",
+    "m31",
+    "m41",
+    "m12",
+    "m22",
+    "m32",
+    "m42",
+    "m13",
+    "m23",
+    "m33",
+    "m43",
+    "m14",
+    "m24",
+    "m34",
+    "m44",
+    NULL
+};
+
 static const struct luaL_Reg modules_matrix4_meta_functions[] = {
     {"__index", modules_matrix4_meta_index},
     {"__newindex", modules_matrix4_meta_newindex},
@@ -976,6 +997,7 @@ int luaopen_matrix4(lua_State* L) {
 
     luaL_newmetatable(L, "matrix4");
     luaL_setfuncs(L, modules_matrix4_meta_functions, 0);
+    lua_setdummyfields(L, modules_matrix4_fields);
 
     lua_pushstring(L, "__gc");
     lua_pushcfunction(L, modules_matrix4_gc);
@@ -985,6 +1007,7 @@ int luaopen_matrix4(lua_State* L) {
 
     luaL_newmetatable(L, "matrix4_nogc");
     luaL_setfuncs(L, modules_matrix4_meta_functions, 0);
+    lua_setdummyfields(L, modules_matrix4_fields);
 
     lua_pop(L, 1);
 

--- a/src/modules/mode7.c
+++ b/src/modules/mode7.c
@@ -12,6 +12,7 @@
 #include <lua/lauxlib.h>
 #include <lua/lualib.h>
 
+#include "luautils.h"
 #include "matrix3.h"
 #include "texture.h"
 #include "vector3.h"
@@ -287,6 +288,13 @@ static int modules_mode7_renderer_meta_index(lua_State* L) {
     return 1;
 }
 
+static const char* modules_mode7_renderer_fields[] = {
+    "clear",
+    "render",
+    "feature",
+    NULL
+};
+
 static const struct luaL_Reg modules_mode7_renderer_functions[] = {
     {"new", modules_mode7_renderer_new},
     {"clear", modules_mode7_renderer_clear},
@@ -450,6 +458,16 @@ static int modules_mode7_camera_meta_newindex(lua_State* L) {
     return 0;
 }
 
+static const char* modules_mode7_camera_fields[] = {
+    "position",
+    "pitch",
+    "yaw",
+    "fov",
+    "near",
+    "far",
+    NULL
+};
+
 static const struct luaL_Reg modules_mode7_camera_functions[] = {
     {"new", modules_mode7_camera_new},
     {NULL, NULL}
@@ -471,6 +489,7 @@ int luaopen_mode7(lua_State* L) {
 
     luaL_newmetatable(L, "mode7_renderer");
     luaL_setfuncs(L, modules_mode7_renderer_meta_functions, 0);
+    lua_setdummyfields(L, modules_mode7_renderer_fields);
     lua_pop(L, 1);
 
     lua_pushstring(L, "Camera");
@@ -479,6 +498,7 @@ int luaopen_mode7(lua_State* L) {
 
     luaL_newmetatable(L, "mode7_camera");
     luaL_setfuncs(L, modules_mode7_camera_meta_functions, 0);
+    lua_setdummyfields(L, modules_mode7_camera_fields);
     lua_pop(L, 1);
 
     return 1;

--- a/src/modules/quaternion.c
+++ b/src/modules/quaternion.c
@@ -11,6 +11,7 @@
 
 #include <mathc/mathc.h>
 
+#include "luautils.h"
 #include "matrix4.h"
 #include "quaternion.h"
 #include "vector3.h"
@@ -693,6 +694,14 @@ static int modules_quaternion_meta_tostring(lua_State* L) {
     return 1;
 }
 
+static const char* modules_quaternion_fields[] = {
+    "x",
+    "y",
+    "z",
+    "w",
+    NULL
+};
+
 static const struct luaL_Reg modules_quaternion_meta_functions[] = {
     {"__index", modules_quaternion_meta_index},
     {"__newindex", modules_quaternion_meta_newindex},
@@ -710,6 +719,7 @@ int luaopen_quaternion(lua_State* L) {
 
     luaL_newmetatable(L, "quaternion");
     luaL_setfuncs(L, modules_quaternion_meta_functions, 0);
+    lua_setdummyfields(L, modules_quaternion_fields);
 
     lua_pushstring(L, "__gc");
     lua_pushcfunction(L, modules_quaternion_gc);
@@ -719,6 +729,7 @@ int luaopen_quaternion(lua_State* L) {
 
     luaL_newmetatable(L, "quaternion_nogc");
     luaL_setfuncs(L, modules_quaternion_meta_functions, 0);
+    lua_setdummyfields(L, modules_quaternion_fields);
 
     lua_pop(L, 1);
 

--- a/src/modules/raycaster.c
+++ b/src/modules/raycaster.c
@@ -44,6 +44,7 @@
 
 #include <mathc/mathc.h>
 
+#include "luautils.h"
 #include "raycaster.h"
 #include "texture.h"
 #include "vector2.h"
@@ -493,9 +494,31 @@ static int modules_raycaster_map_new(lua_State* L) {
  * @tfield {integer,...} ceilings Array of integers
  */
 
+static const char* modules_raycaster_map_fields[] = {
+    "walls",
+    "floors",
+    "ceilings",
+    NULL
+};
+
 static const struct luaL_Reg modules_raycaster_map_functions[] = {
     {"new", modules_raycaster_map_new},
     {NULL, NULL}
+};
+
+static const struct luaL_Reg modules_raycaster_map_meta_functions[] = {
+    {"__index", modules_raycaster_map_meta_index},
+    {"__newindex", modules_raycaster_map_meta_newindex},
+    {"__gc", modules_raycaster_map_meta_gc},
+    {NULL, NULL}
+};
+
+static const char* modules_raycaster_renderer_fields[] = {
+    "clear",
+    "render",
+    "camera",
+    "feature",
+    NULL
 };
 
 static const struct luaL_Reg modules_raycaster_renderer_functions[] = {
@@ -513,13 +536,6 @@ static const struct luaL_Reg modules_raycaster_renderer_meta_functions[] = {
     {NULL, NULL}
 };
 
-static const struct luaL_Reg modules_raycaster_map_meta_functions[] = {
-    {"__index", modules_raycaster_map_meta_index},
-    {"__newindex", modules_raycaster_map_meta_newindex},
-    {"__gc", modules_raycaster_map_meta_gc},
-    {NULL, NULL}
-};
-
 int luaopen_raycaster(lua_State* L) {
     lua_newtable(L);
 
@@ -529,6 +545,7 @@ int luaopen_raycaster(lua_State* L) {
 
     luaL_newmetatable(L, "raycaster_renderer");
     luaL_setfuncs(L, modules_raycaster_renderer_meta_functions, 0);
+    lua_setdummyfields(L, modules_raycaster_renderer_fields);
     lua_pop(L, 1);
 
     lua_pushstring(L, "Map");
@@ -537,6 +554,7 @@ int luaopen_raycaster(lua_State* L) {
 
     luaL_newmetatable(L, "raycaster_map");
     luaL_setfuncs(L, modules_raycaster_map_meta_functions, 0);
+    lua_setdummyfields(L, modules_raycaster_map_fields);
     lua_pop(L, 1);
 
     return 1;

--- a/src/modules/sound.c
+++ b/src/modules/sound.c
@@ -9,6 +9,7 @@
 #include <lua/lauxlib.h>
 #include <lua/lualib.h>
 
+#include "luautils.h"
 #include "sound.h"
 
 #include "../log.h"
@@ -129,13 +130,6 @@ static int modules_sound_meta_tostring(lua_State* L) {
 
     return 1;
 }
-
-static const struct luaL_Reg modules_sound_meta_functions[] = {
-    {"__index", modules_sound_meta_index},
-    {"__newindex", modules_sound_meta_newindex},
-    {"__tostring", modules_sound_meta_tostring},
-    {NULL, NULL}
-};
 
 /**
  * Create new sound.
@@ -281,6 +275,13 @@ static int modules_sound_frame_get(lua_State* L) {
  * @tfield integer frame_count (read-only)
  */
 
+static const char* modules_sound_fields[] = {
+    "play",
+    "copy",
+    "pcm",
+    NULL
+};
+
 static const struct luaL_Reg modules_sound_functions[] = {
     {"new", modules_sound_new},
     {"copy", modules_sound_copy},
@@ -292,12 +293,20 @@ static const struct luaL_Reg modules_sound_functions[] = {
     {NULL, NULL}
 };
 
+static const struct luaL_Reg modules_sound_meta_functions[] = {
+    {"__index", modules_sound_meta_index},
+    {"__newindex", modules_sound_meta_newindex},
+    {"__tostring", modules_sound_meta_tostring},
+    {NULL, NULL}
+};
+
 int luaopen_sound(lua_State* L) {
     luaL_newlib(L, modules_sound_functions);
 
     // Push sound userdata metatable
     luaL_newmetatable(L, "sound");
     luaL_setfuncs(L, modules_sound_meta_functions, 0);
+    lua_setdummyfields(L, modules_sound_fields);
 
     lua_pushstring(L, "__gc");
     lua_pushcfunction(L, modules_sound_gc);
@@ -308,6 +317,7 @@ int luaopen_sound(lua_State* L) {
     // Push sound userdata metatable
     luaL_newmetatable(L, "sound_nogc");
     luaL_setfuncs(L, modules_sound_meta_functions, 0);
+    lua_setdummyfields(L, modules_sound_fields);
 
     lua_pop(L, 1);
 

--- a/src/modules/texture.c
+++ b/src/modules/texture.c
@@ -9,6 +9,7 @@
 #include <lua/lauxlib.h>
 #include <lua/lualib.h>
 
+#include "luautils.h"
 #include "texture.h"
 
 #include "../assets.h"
@@ -172,13 +173,6 @@ static int modules_texture_meta_tostring(lua_State* L) {
 
     return 1;
 }
-
-static const struct luaL_Reg modules_texture_meta_functions[] = {
-    {"__index", modules_texture_meta_index},
-    {"__newindex", modules_texture_meta_newindex},
-    {"__tostring", modules_texture_meta_tostring},
-    {NULL, NULL}
-};
 
 /**
  * Create new texture.
@@ -408,6 +402,18 @@ static int modules_texture_blit(lua_State* L) {
  * @tfield integer height (read-only)
  */
 
+static const char* modules_texture_fields[] = {
+    "copy",
+    "sub",
+    "clear",
+    "clear",
+    "blit",
+    "pixels",
+    "width",
+    "height",
+    NULL
+};
+
 static const struct luaL_Reg modules_texture_functions[] = {
     {"new", modules_texture_new},
     {"copy", modules_texture_copy},
@@ -419,12 +425,20 @@ static const struct luaL_Reg modules_texture_functions[] = {
     {NULL, NULL}
 };
 
+static const struct luaL_Reg modules_texture_meta_functions[] = {
+    {"__index", modules_texture_meta_index},
+    {"__newindex", modules_texture_meta_newindex},
+    {"__tostring", modules_texture_meta_tostring},
+    {NULL, NULL}
+};
+
 int luaopen_texture(lua_State* L) {
     luaL_newlib(L, modules_texture_functions);
 
     // Push texture userdata metatable
     luaL_newmetatable(L, "texture");
     luaL_setfuncs(L, modules_texture_meta_functions, 0);
+    lua_setdummyfields(L, modules_texture_fields);
 
     lua_pushstring(L, "__gc");
     lua_pushcfunction(L, texture_gc);
@@ -435,6 +449,7 @@ int luaopen_texture(lua_State* L) {
     // Push texture_nogc userdata metatable
     luaL_newmetatable(L, "texture_nogc");
     luaL_setfuncs(L, modules_texture_meta_functions, 0);
+    lua_setdummyfields(L, modules_texture_fields);
 
     lua_pop(L, 1);
 

--- a/src/modules/vector2.c
+++ b/src/modules/vector2.c
@@ -11,6 +11,7 @@
 
 #include <mathc/mathc.h>
 
+#include "luautils.h"
 #include "vector2.h"
 
 #include "../log.h"
@@ -859,6 +860,12 @@ static int modules_vector2_meta_tostring(lua_State* L) {
     return 1;
 }
 
+static const char* modules_vector2_fields[] = {
+    "x",
+    "y",
+    NULL
+};
+
 static const struct luaL_Reg modules_vector2_meta_functions[] = {
     {"__index", modules_vector2_meta_index},
     {"__newindex", modules_vector2_meta_newindex},
@@ -878,6 +885,7 @@ int luaopen_vector2(lua_State* L) {
 
     luaL_newmetatable(L, "vector2");
     luaL_setfuncs(L, modules_vector2_meta_functions, 0);
+    lua_setdummyfields(L, modules_vector2_fields);
 
     lua_pushstring(L, "__gc");
     lua_pushcfunction(L, modules_vector2_gc);
@@ -887,6 +895,7 @@ int luaopen_vector2(lua_State* L) {
 
     luaL_newmetatable(L, "vector2_nogc");
     luaL_setfuncs(L, modules_vector2_meta_functions, 0);
+    lua_setdummyfields(L, modules_vector2_fields);
 
     lua_pop(L, 1);
 

--- a/src/modules/vector3.c
+++ b/src/modules/vector3.c
@@ -12,6 +12,7 @@
 
 #include <mathc/mathc.h>
 
+#include "luautils.h"
 #include "vector3.h"
 
 #include "../log.h"
@@ -939,6 +940,13 @@ static int modules_vector3_meta_tostring(lua_State* L) {
     return 1;
 }
 
+static const char* modules_vector3_fields[] = {
+    "x",
+    "y",
+    "z",
+    NULL
+};
+
 static const struct luaL_Reg modules_vector3_meta_functions[] = {
     {"__index", modules_vector3_meta_index},
     {"__newindex", modules_vector3_meta_newindex},
@@ -958,6 +966,7 @@ int luaopen_vector3(lua_State* L) {
 
     luaL_newmetatable(L, "vector3");
     luaL_setfuncs(L, modules_vector3_meta_functions, 0);
+    lua_setdummyfields(L, modules_vector3_fields);
 
     lua_pushstring(L, "__gc");
     lua_pushcfunction(L, vector3_gc);
@@ -967,6 +976,7 @@ int luaopen_vector3(lua_State* L) {
 
     luaL_newmetatable(L, "vector3_nogc");
     luaL_setfuncs(L, modules_vector3_meta_functions, 0);
+    lua_setdummyfields(L, modules_vector3_fields);
 
     lua_pop(L, 1);
 

--- a/src/modules/vector4.c
+++ b/src/modules/vector4.c
@@ -12,6 +12,7 @@
 
 #include <mathc/mathc.h>
 
+#include "luautils.h"
 #include "vector4.h"
 
 #include "../log.h"
@@ -713,6 +714,14 @@ static int modules_vector4_meta_tostring(lua_State* L) {
     return 1;
 }
 
+static const char* modules_vector4_fields[] = {
+    "x",
+    "y",
+    "z",
+    "w",
+    NULL
+};
+
 static const struct luaL_Reg modules_vector4_meta_functions[] = {
     {"__index", modules_vector4_meta_index},
     {"__newindex", modules_vector4_meta_newindex},
@@ -732,6 +741,7 @@ int luaopen_vector4(lua_State* L) {
 
     luaL_newmetatable(L, "vector4");
     luaL_setfuncs(L, modules_vector4_meta_functions, 0);
+    lua_setdummyfields(L, modules_vector4_fields);
 
     lua_pushstring(L, "__gc");
     lua_pushcfunction(L, vector4_gc);
@@ -741,6 +751,7 @@ int luaopen_vector4(lua_State* L) {
 
     luaL_newmetatable(L, "vector4_nogc");
     luaL_setfuncs(L, modules_vector4_meta_functions, 0);
+    lua_setdummyfields(L, modules_vector4_fields);
 
     lua_pop(L, 1);
 


### PR DESCRIPTION
# Summary
Adds dummy fields to userdata metatables so the autocomplete experience is better. This should be done for all fields that are handled inside a C __index function.